### PR TITLE
feat: 공용 Input 컴포넌트 추가

### DIFF
--- a/components/common/Input.tsx
+++ b/components/common/Input.tsx
@@ -35,9 +35,13 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
     return (
       <div>
         <div>
-          <label className="text-lg text-gray70 font-medium">{label}</label>
+          <label className="tablet:text-lg mobile:text-base text-gray70 font-medium ">
+            {label}
+          </label>
           {required && (
-            <span className="text-lg text-violet font-medium"> *</span>
+            <span className="tablet:text-lg mobile:text-base text-violet font-medium">
+              *
+            </span>
           )}
         </div>
         <div className="mt-2.5">
@@ -50,7 +54,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
             onBlur={onBlur}
             className={`block w-full rounded-md border border-solid ${
               hasError ? 'border-red' : 'border-gray30'
-            } px-4 py-3.5 text-base text-gray70 placeholder:text-gray40 focus:border-violet outline-0`}
+            } px-4 py-3.5 tablet:text-base mobile:text-sm text-gray70 placeholder:text-gray40 focus:border-violet outline-0`}
           />
         </div>
         {hasError && <p className="text-sm text-red mt-2">{helperText}</p>}

--- a/components/common/Input.tsx
+++ b/components/common/Input.tsx
@@ -1,0 +1,62 @@
+import {
+  ChangeEventHandler,
+  FocusEventHandler,
+  HTMLInputTypeAttribute,
+  forwardRef,
+} from 'react';
+
+export interface InputProps {
+  label?: string;
+  placeholder: string;
+  value: string | number;
+  type?: HTMLInputTypeAttribute;
+  hasError?: boolean;
+  helperText?: string;
+  onChange: ChangeEventHandler<HTMLInputElement>;
+  onBlur?: FocusEventHandler<HTMLInputElement>;
+  required?: boolean;
+}
+
+const Input = forwardRef<HTMLInputElement, InputProps>(
+  (
+    {
+      label,
+      placeholder,
+      value,
+      type = 'text',
+      hasError = false,
+      helperText,
+      onChange,
+      onBlur,
+      required = false,
+    },
+    ref
+  ) => {
+    return (
+      <div>
+        <div>
+          <label className="text-lg text-gray70 font-medium">{label}</label>
+          {required && (
+            <span className="text-lg text-violet font-medium"> *</span>
+          )}
+        </div>
+        <div className="mt-2.5">
+          <input
+            ref={ref}
+            placeholder={placeholder}
+            type={type}
+            value={value}
+            onChange={onChange}
+            onBlur={onBlur}
+            className={`block w-full rounded-md border border-solid ${
+              hasError ? 'border-red' : 'border-gray30'
+            } px-4 py-3.5 text-base text-gray70 placeholder:text-gray40 focus:border-violet outline-0`}
+          />
+        </div>
+        {hasError && <p className="text-sm text-red mt-2">{helperText}</p>}
+      </div>
+    );
+  }
+);
+
+export default Input;

--- a/components/index.ts
+++ b/components/index.ts
@@ -1,0 +1,1 @@
+export { default as Input } from './common/Input';


### PR DESCRIPTION
## 🛠️주요 변경 사항
- 공용 Input 컴포넌트 추가

## 📣리뷰어에게 하고싶은 말
- react-hook-form 사용을 고려하여 forwardRef로 감쌌습니다.
- w-full 으로, 가로 크기는 부모 div 크기에 맞춰집니다.
- 승연님 작업하시던 input 컴포넌트에서 변경점은 아래 코멘트로 달아두겠습니다!
    - label, required 속성, 스타일링만 차이가 있습니다.
- passwordInput은 승연님께서 작업해두신 것이 있어서 작업하지 않았습니다.

## 🖼️스크린샷
<img width="217" alt="Input컴포넌트" src="https://github.com/codeit-sprint-team1/Taskify/assets/144652458/62da7a52-309f-41fe-9dbe-29d1a540fe0a">

## ❗관련이슈
- Close #30 
