### PR TITLE
feat: 공용 버튼 컴포넌트 생성

### DIFF
--- a/components/common/Button.tsx
+++ b/components/common/Button.tsx
@@ -1,0 +1,85 @@
+import React, { ReactNode } from 'react';
+
+type Variant = 'primary' | 'secondary' | 'modal' | 'inactive';
+type Size = 'desktop' | 'tablet' | 'mobile' | 'large' | 'small' | 'sign';
+
+interface ButtonProps {
+  variant: Variant;
+  type?: 'submit' | undefined;
+  size: Size;
+  className?: String;
+  onClick?: () => void;
+  children: ReactNode;
+}
+
+function Button({
+  variant,
+  type,
+  size,
+  className,
+  onClick,
+  children,
+}: ButtonProps) {
+  let combinedClassName = '';
+  switch (variant) {
+    case 'primary': {
+      combinedClassName =
+        'border-none rounded-md flex-center font-medium text-white bg-violet';
+      break;
+    }
+    case 'secondary': {
+      combinedClassName =
+        'border border-gray30 rounded-md flex-center font-medium text-violet bg-white';
+      break;
+    }
+    case 'modal': {
+      combinedClassName =
+        'border border-gray30 rounded-md flex-center font-medium text-gray50 bg-white';
+      break;
+    }
+    case 'inactive': {
+      combinedClassName =
+        'border-none rounded-md flex-center font-medium text-white bg-gray40';
+      break;
+    }
+  }
+
+  switch (size) {
+    case 'desktop': {
+      combinedClassName += ' py-[0.4375rem] px-[1.8125rem] text-sm ';
+      break;
+    }
+    case 'tablet': {
+      combinedClassName += ' py-[0.375rem] px-[1.4375rem] text-sm ';
+      break;
+    }
+    case 'mobile': {
+      combinedClassName += ' py-[0.4375rem] px-[2.3125rem] text-xs ';
+      break;
+    }
+    case 'large': {
+      combinedClassName += ' py-[0.4375rem] px-[1.8125rem] text-sm';
+      break;
+    }
+    case 'small': {
+      combinedClassName += ' py-[0.4375rem] px-[0.5625rem] text-xs w-[3.25rem]';
+      break;
+    }
+    case 'sign': {
+      combinedClassName += ' py-[0.875rem] px-[14.75rem] text-lg ';
+      break;
+    }
+  }
+
+  return (
+    <button
+      className={`${combinedClassName} ${className}`}
+      type={type ? type : 'button'}
+      onClick={onClick}
+    >
+      {children}
+    </button>
+  );
+}
+
+export default Button;

--- a/components/index.ts
+++ b/components/index.ts
@@ -1,0 +1,1 @@
+export { default as Button } from './common/Button';


### PR DESCRIPTION
## 🛠️주요 변경 사항
- 재사용 가능한 버튼 컴포넌트 제작 했습니다.

## 📣리뷰어에게 하고싶은 말
- 사용방법은 size와 variant props로 사용하고자 하는 디자인을 선택 해 주시고, 필요에 따라 다른 디자인이 들어가야 할 때는 className props에 추가로 스타일을 지정해서 넣어주시면 됩니다.

## 🖼️스크린샷(선택)
![스크린샷 2023-12-19 오후 3 55 57](https://github.com/codeit-sprint-team1/Taskify/assets/90304025/b2c5b877-d732-4dd4-949f-762aa93624e7)

## ❗관련이슈
- close #29 