### PR TITLE
refactor: login, signup form 라벨표현, 버튼활성화, 컴포넌트 import 방식 변경

### DIFF
--- a/components/common/Button.tsx
+++ b/components/common/Button.tsx
@@ -8,7 +8,8 @@ type Size =
   | 'xsmall'
   | 'small'
   | 'sign'
-  | 'responsive';
+  | 'responsive'
+  | 'modal';
 
 interface ButtonProps {
   variant: Variant;
@@ -70,6 +71,10 @@ function Button({
     case 'responsive': {
       combinedClassName +=
         ' desktop:py-7pxr desktop:px-29pxr desktop:text-14pxr tablet:py-6pxr tablet:px-23pxr tablet:text-14pxr mobile:py-7pxr mobile:px-37pxr mobile:text-12pxr';
+    }
+    case 'modal': {
+      combinedClassName +=
+        ' text-16pxr w-120pxr h-48pxr py-14pxr px-14pxr mobile:text-14pxr mobile:w-138pxr mobile:h-42pxr mobile:py-12pxr mobile:px-12pxr';
     }
     case 'small': {
       combinedClassName += ' py-7pxr px-29pxr text-14pxr';

--- a/components/common/Input.tsx
+++ b/components/common/Input.tsx
@@ -15,7 +15,6 @@ export interface InputProps {
   onChange: ChangeEventHandler<HTMLInputElement>;
   onBlur?: FocusEventHandler<HTMLInputElement>;
   required?: boolean;
-  maxLength?: number;
 }
 
 const Input = forwardRef<HTMLInputElement, InputProps>(
@@ -35,15 +34,9 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
   ) => {
     return (
       <div>
-        <div>
-          <label className="tablet:text-lg mobile:text-base text-gray70 font-medium ">
-            {label}
-          </label>
-          {required && (
-            <span className="tablet:text-lg mobile:text-base text-violet font-medium">
-              *
-            </span>
-          )}
+        <div className="font-medium mb-10pxr text-18pxr text-gray70 mobile:text-16pxr ">
+          <label>{label}</label>
+          {required && <span className="text-violet">*</span>}
         </div>
         <div className="mt-2.5">
           <input
@@ -55,10 +48,12 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
             onBlur={onBlur}
             className={`block w-full rounded-md border border-solid ${
               hasError ? 'border-red' : 'border-gray30'
-            } px-4 py-3.5 tablet:text-base mobile:text-sm text-gray70 placeholder:text-gray40 focus:border-violet outline-0`}
+            } px-16pxr py-15pxr tablet:text-16pxr mobile:text-14pxr text-gray70 placeholder:text-gray40 focus:border-violet outline-0`}
           />
         </div>
-        {hasError && <p className="text-sm text-red mt-2">{helperText}</p>}
+        {hasError && (
+          <p className="text-14pxr text-red mt-8pxr">{helperText}</p>
+        )}
       </div>
     );
   }

--- a/components/common/PasswordInput.tsx
+++ b/components/common/PasswordInput.tsx
@@ -11,6 +11,7 @@ type PasswordInputProps = {
 const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(
   (
     {
+      label,
       hasEyeIcon = false,
       value,
       placeholder,
@@ -46,6 +47,7 @@ const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(
       <div>
         <Input
           ref={ref}
+          label={label}
           value={value}
           placeholder={placeholder}
           type={inputType}

--- a/components/index.ts
+++ b/components/index.ts
@@ -1,4 +1,9 @@
-export { default as ColorChips } from './common/ColorChips';
+export { default as SignHeader } from './sign/header/SignHeader';
+export { default as SignFooter } from './sign/footer/SignFooter';
+export { default as LoginForm } from './sign/form/LoginForm';
+export { default as SignUpForm } from './sign/form/SignUpForm';
 export { default as Button } from './common/Button';
+export { default as ColorChips } from './common/ColorChips';
 export { default as Input } from './common/Input';
-export { default as PasswordInput} from './common/PasswordInput'
+export { default as PasswordInput } from './common/PasswordInput';
+export { default as Modal } from './modal/Modal';

--- a/components/sign/footer/SignFooter.tsx
+++ b/components/sign/footer/SignFooter.tsx
@@ -3,7 +3,7 @@ import { BUTTON_TEXT, LINK_TEXT } from '../constants';
 import { useRouter } from 'next/router';
 import { ROUTE } from '@/constants/constants';
 
-export function SignFooter() {
+export default function SignFooter() {
   const router = useRouter();
   const isLoginPage = router.pathname === '/login';
 

--- a/components/sign/form/LoginForm.tsx
+++ b/components/sign/form/LoginForm.tsx
@@ -11,13 +11,12 @@ import { Button, PasswordInput, Input } from '@/components';
 import { useLogin, useTokenRedirect } from '../data';
 
 export default function LoginForm() {
-  const [isButtonDisabled, setIsButtonDisabled] = useState(false);
   const {
     control,
     handleSubmit,
     watch,
     setError,
-    formState: { errors },
+    formState: { errors, isValid },
   } = useForm({
     defaultValues: { email: '', password: '' },
     mode: 'onBlur',
@@ -44,13 +43,6 @@ export default function LoginForm() {
       });
     }
   }, [error, setError]);
-
-  useEffect(() => {
-    const areFieldsFilled = watchedFields.every((field) => field);
-    const hasNoErrors = Object?.keys(errors).length === 0;
-
-    setIsButtonDisabled(!(areFieldsFilled && hasNoErrors));
-  }, [watchedFields, errors]);
 
   return (
     <form onSubmit={handleSubmit(login)}>
@@ -101,9 +93,9 @@ export default function LoginForm() {
       </div>
       <Button
         type="submit"
-        disabled={isButtonDisabled}
+        disabled={!isValid}
         size="sign"
-        variant={isButtonDisabled ? 'inactive' : 'primary'}
+        variant={isValid ? 'primary' : 'inactive'}
       >
         {BUTTON_TEXT.login}
       </Button>

--- a/components/sign/form/LoginForm.tsx
+++ b/components/sign/form/LoginForm.tsx
@@ -10,7 +10,7 @@ import { useEffect, useState } from 'react';
 import { Button, PasswordInput, Input } from '@/components';
 import { useLogin, useTokenRedirect } from '../data';
 
-export const LoginForm = () => {
+export default function LoginForm() {
   const [isButtonDisabled, setIsButtonDisabled] = useState(false);
   const {
     control,
@@ -109,4 +109,4 @@ export const LoginForm = () => {
       </Button>
     </form>
   );
-};
+}

--- a/components/sign/form/SignUpForm.tsx
+++ b/components/sign/form/SignUpForm.tsx
@@ -74,7 +74,6 @@ export default function SignUpForm() {
   return (
     <form onSubmit={handleSubmit(signUp)}>
       <div>
-        <label>이메일</label>
         <Controller
           control={control}
           name="email"
@@ -88,6 +87,7 @@ export default function SignUpForm() {
           render={({ field, fieldState }) => (
             <Input
               {...field}
+              label="이메일"
               placeholder={PLACEHOLDER.email}
               hasError={Boolean(fieldState.error) || isEmailAlreadyExist}
               helperText={
@@ -100,7 +100,6 @@ export default function SignUpForm() {
         />
       </div>
       <div>
-        <label>닉네임</label>
         <Controller
           control={control}
           name="nickname"
@@ -118,16 +117,15 @@ export default function SignUpForm() {
           render={({ field, fieldState }) => (
             <Input
               {...field}
+              label="닉네임"
               placeholder={PLACEHOLDER.nickname}
               hasError={Boolean(fieldState.error)}
               helperText={fieldState.error?.message}
-              maxLength={10}
             />
           )}
         />
       </div>
       <div>
-        <label>비밀번호</label>
         <Controller
           control={control}
           name="password"
@@ -141,6 +139,7 @@ export default function SignUpForm() {
           render={({ field, fieldState }) => (
             <PasswordInput
               {...field}
+              label="비밀번호"
               hasEyeIcon
               placeholder={PLACEHOLDER.password}
               hasError={Boolean(fieldState.error)}
@@ -150,7 +149,6 @@ export default function SignUpForm() {
         />
       </div>
       <div>
-        <label>비밀번호 확인</label>
         <Controller
           control={control}
           name="confirmedPassword"
@@ -167,6 +165,7 @@ export default function SignUpForm() {
           render={({ field, fieldState }) => (
             <PasswordInput
               {...field}
+              label="비밀번호 확인"
               hasEyeIcon
               placeholder={PLACEHOLDER.confirmedPassword}
               hasError={Boolean(fieldState.error)}

--- a/components/sign/form/SignUpForm.tsx
+++ b/components/sign/form/SignUpForm.tsx
@@ -15,13 +15,12 @@ import { useSignUp, useTokenRedirect } from '../data';
 
 export default function SignUpForm() {
   const router = useRouter();
-  const [isButtonDisabled, setIsButtonDisabled] = useState(true);
 
   const {
     control,
     handleSubmit,
     watch,
-    formState: { errors },
+    formState: { errors, isValid },
   } = useForm({
     defaultValues: {
       email: '',
@@ -62,14 +61,6 @@ export default function SignUpForm() {
       router.replace('login');
     }
   }, [data]);
-
-  useEffect(() => {
-    const areFieldsFilled = watchedFields.every((field) => field);
-    const isCheckboxChecked = watchedFields[watchedFields.length - 1];
-    const hasNoErrors = Object?.keys(errors).length === 0;
-
-    setIsButtonDisabled(!(areFieldsFilled && isCheckboxChecked && hasNoErrors));
-  }, [watchedFields, errors]);
 
   return (
     <form onSubmit={handleSubmit(signUp)}>
@@ -177,6 +168,9 @@ export default function SignUpForm() {
       <Controller
         control={control}
         name="termsOfUse"
+        rules={{
+          required: true,
+        }}
         render={({ field: { onChange, onBlur, value, ref } }) => (
           <div>
             <input
@@ -192,9 +186,9 @@ export default function SignUpForm() {
       />
       <Button
         type="submit"
-        disabled={isButtonDisabled}
+        disabled={!isValid}
         size="sign"
-        variant={isButtonDisabled ? 'inactive' : 'primary'}
+        variant={isValid ? 'primary' : 'inactive'}
       >
         {BUTTON_TEXT.signUp}
       </Button>

--- a/components/sign/header/SignHeader.tsx
+++ b/components/sign/header/SignHeader.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/router';
 import { WELLCOME_MESSAGE } from '../constants';
 import Link from 'next/link';
 
-export function SignHeader() {
+export default function SignHeader() {
   const router = useRouter();
   const isLoginPage = router.pathname === '/login';
 

--- a/pages/login/index.tsx
+++ b/pages/login/index.tsx
@@ -1,4 +1,4 @@
-import { LoginForm, SignFooter, SignHeader } from '@/components/sign';
+import { LoginForm, SignFooter, SignHeader } from '@/components/index';
 import SignLayout from '@/page-layout/SignLayout';
 
 export default function LoginPage() {

--- a/pages/signup/index.tsx
+++ b/pages/signup/index.tsx
@@ -1,5 +1,4 @@
-import { SignFooter, SignHeader } from '@/components/sign';
-import SignUpForm from '@/components/sign/form/SignUpForm';
+import { SignFooter, SignHeader, SignUpForm } from '@/components/index';
 import SignLayout from '@/page-layout/SignLayout';
 
 export default function SignUpPage() {


### PR DESCRIPTION
## 🛠️주요 변경 사항
- 컴포넌트 component/index.ts 로 모은 후에 import 하는 방식으로 변경했습니다.
- label 직접 삽입이 아닌 input 컴포넌트에 있는 label 속성을 활용했습니다.
- 버튼 활성화는 react-hook-form의 상태인 'isValid' 활용 했습니다. 
- Input 공용 컴포넌트 단위 pxr로 수정했습니다.

## 📣리뷰어에게 하고싶은 말
- 사실 input 컴포넌트 라벨은 폰트가 18px인고, 로그인 페이지는 16px인데 그냥 18px로 통일해도 괜찮겠죠?
- react-hook-form의 isValid는 form에 에러가 하나도 없을 경우에만 true가 됩니다.

## 🖼️스크린샷(선택)

## ❗관련이슈
- #39 
