### PR TITLE
refactor: 컬러칩 색상코드값, colorName 키 추가

### DIFF
--- a/components/common/ColorChips.tsx
+++ b/components/common/ColorChips.tsx
@@ -10,16 +10,17 @@ interface ColorChipsProps {
 interface PaletteType {
   key: string;
   value: string;
+  colorName: string;
   checked: boolean;
 }
 
 function ColorChips({ onSelect }: ColorChipsProps) {
   const [isSelect, setIsSelect] = useState([
-    { key: '0', value: 'bg-green', checked: false },
-    { key: '1', value: 'bg-violet', checked: false },
-    { key: '2', value: 'bg-orange', checked: false },
-    { key: '3', value: 'bg-blue', checked: false },
-    { key: '4', value: 'bg-pink', checked: false },
+    { key: '0', value: '#7ac555', colorName: 'bg-green', checked: false },
+    { key: '1', value: '#5534da', colorName: 'bg-violet', checked: false },
+    { key: '2', value: '#ffa500', colorName: 'bg-orange', checked: false },
+    { key: '3', value: '#76a5ea', colorName: 'bg-blue', checked: false },
+    { key: '4', value: '#e876ea', colorName: 'bg-pink', checked: false },
   ]);
 
   const onChangeCheck =
@@ -44,7 +45,7 @@ function ColorChips({ onSelect }: ColorChipsProps) {
             className="hidden"
           />
           <motion.div
-            className={`w-30pxr h-30pxr rounded-full cursor-pointer flex-center ${element.value}`}
+            className={`w-30pxr h-30pxr rounded-full cursor-pointer flex-center ${element.colorName}`}
             whileTap={{ scale: 0.7 }}
           >
             {element.checked && (


### PR DESCRIPTION
## 🛠️주요 변경 사항
- ColorChip 컴포넌트에서 컬러코드값을 추가하여 API request에 사용할 수 있도록 했습니다.
- 기존 'bg-{색상명}'은 colorName 키에 저장했습니다.

## 📣리뷰어에게 하고싶은 말
- 사용할 때 달라진 것은 없을거예요.

## 🖼️스크린샷(선택)
![Screen Shot 2023-12-21 at 09 58 24](https://github.com/codeit-sprint-team1/Taskify/assets/144652458/1643d33f-ef57-4523-bd94-1e6bd883fa4f)

## ❗관련이슈
- #33 
