### PR TITLE
feat: 대시보드 생성 모달 구현

### DIFF
--- a/components/index.ts
+++ b/components/index.ts
@@ -6,3 +6,8 @@ export { default as SignHeader } from './sign/header/SignHeader';
 export { default as SignFooter } from './sign/footer/SignFooter';
 export { default as LoginForm } from './sign/form/LoginForm';
 export { default as SignUpForm } from './sign/form/SignUpForm';
+export { default as ModalButton } from './modal/ModalButton';
+export { default as ModalTitle } from './modal/ModalTitle';
+export { default as Portal } from './modal/Portal';
+export { default as Modal } from './modal/Modal';
+export { default as InputModal } from './modal/InputModal';

--- a/components/index.ts
+++ b/components/index.ts
@@ -10,4 +10,4 @@ export { default as ModalButton } from './modal/ModalButton';
 export { default as ModalTitle } from './modal/ModalTitle';
 export { default as Portal } from './modal/Portal';
 export { default as Modal } from './modal/Modal';
-export { default as InputModal } from './modal/InputModal';
+export { default as CreateDashboardModal } from './modal/CreateDashboardModal';

--- a/components/modal/CreateDashboardModal.tsx
+++ b/components/modal/CreateDashboardModal.tsx
@@ -5,7 +5,7 @@ import usePostDashboard from './data/usePostDashboard';
 
 interface CreateDashboardModalProps {
   isOpen: boolean;
-  onCancle: () => void;
+  onCancel: () => void;
 }
 
 export interface CreateDashboardModalForm {
@@ -14,7 +14,7 @@ export interface CreateDashboardModalForm {
 
 export default function CreateDashboardModal({
   isOpen,
-  onCancle,
+  onCancel: onCancel,
 }: CreateDashboardModalProps) {
   const [color, setColor] = useState<string>('');
 
@@ -37,16 +37,16 @@ export default function CreateDashboardModal({
     color: color,
   });
 
-  const handleCancle = () => {
+  const handleCancel = () => {
     reset();
     setColor('');
-    onCancle();
+    onCancel();
   };
 
   const onSubmit = () => {
     postDashboard();
     if (isSubmitSuccessful) {
-      handleCancle();
+      handleCancel();
     }
   };
 
@@ -74,7 +74,7 @@ export default function CreateDashboardModal({
         <Modal.ColorChips onSelect={onSelect} />
         <Modal.Button
           disabled={!isValid || color === ''}
-          onCancle={handleCancle}
+          onCancel={handleCancel}
         >
           생성
         </Modal.Button>

--- a/components/modal/CreateDashboardModal.tsx
+++ b/components/modal/CreateDashboardModal.tsx
@@ -3,16 +3,19 @@ import { useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import usePostDashboard from './data/usePostDashboard';
 
-interface InputModalProps {
+interface CreateDashboardModalProps {
   isOpen: boolean;
   onCancle: () => void;
 }
 
-export interface InputModalForm {
+export interface CreateDashboardModalForm {
   title: string;
 }
 
-export default function InputModal({ isOpen, onCancle }: InputModalProps) {
+export default function InputModal({
+  isOpen,
+  onCancle,
+}: CreateDashboardModalProps) {
   const [color, setColor] = useState<string>('');
 
   const {
@@ -21,7 +24,7 @@ export default function InputModal({ isOpen, onCancle }: InputModalProps) {
     watch,
     reset,
     formState: { isValid, isSubmitSuccessful },
-  } = useForm<InputModalForm>();
+  } = useForm<CreateDashboardModalForm>();
 
   const watchInput = watch('title');
 
@@ -29,7 +32,7 @@ export default function InputModal({ isOpen, onCancle }: InputModalProps) {
     setColor(value);
   };
 
-  const { execute: postDashboard, data } = usePostDashboard({
+  const { execute: postDashboard } = usePostDashboard({
     title: watch('title'),
     color: color,
   });

--- a/components/modal/CreateDashboardModal.tsx
+++ b/components/modal/CreateDashboardModal.tsx
@@ -12,7 +12,7 @@ export interface CreateDashboardModalForm {
   title: string;
 }
 
-export default function InputModal({
+export default function CreateDashboardModal({
   isOpen,
   onCancle,
 }: CreateDashboardModalProps) {
@@ -71,7 +71,7 @@ export default function InputModal({
             )}
           />
         </div>
-        <ColorChips onSelect={onSelect} />
+        <Modal.ColorChips onSelect={onSelect} />
         <Modal.Button
           disabled={!isValid || color === ''}
           onCancle={handleCancle}

--- a/components/modal/InputModal.tsx
+++ b/components/modal/InputModal.tsx
@@ -1,0 +1,81 @@
+import { Modal, ColorChips } from '@/components/index';
+import { useState } from 'react';
+import { Controller, useForm } from 'react-hook-form';
+import usePostDashboard from './data/usePostDashboard';
+
+interface InputModalProps {
+  isOpen: boolean;
+  onCancle: () => void;
+}
+
+export interface InputModalForm {
+  title: string;
+}
+
+export default function InputModal({ isOpen, onCancle }: InputModalProps) {
+  const [color, setColor] = useState<string>('');
+
+  const {
+    control,
+    handleSubmit,
+    watch,
+    reset,
+    formState: { isValid, isSubmitSuccessful },
+  } = useForm<InputModalForm>();
+
+  const watchInput = watch('title');
+
+  const onSelect = (value: string) => {
+    setColor(value);
+  };
+
+  const { execute: postDashboard, data } = usePostDashboard({
+    title: watch('title'),
+    color: color,
+  });
+
+  const handleCancle = () => {
+    reset();
+    setColor('');
+    onCancle();
+  };
+
+  const onSubmit = () => {
+    postDashboard();
+    if (isSubmitSuccessful) {
+      handleCancle();
+    }
+  };
+
+  return (
+    <>
+      <Modal isOpen={isOpen} onSubmit={handleSubmit(onSubmit)}>
+        <Modal.Title>대시보드 생성하기</Modal.Title>
+        <div className="flex flex-col gap-24pxr">
+          <Controller
+            name="title"
+            control={control}
+            rules={{ required: true }}
+            render={({ field: { ref, onChange } }) => (
+              <Modal.Input
+                ref={ref}
+                label="대시보드 이름"
+                placeholder="대시보드 이름을 입력해주세요"
+                type="text"
+                value={watchInput}
+                onChange={onChange}
+              />
+            )}
+          />
+        </div>
+        <ColorChips onSelect={onSelect} />
+        <Modal.Button
+          disabled={!isValid || color === ''}
+          onCancle={handleCancle}
+        >
+          생성
+        </Modal.Button>
+      </Modal>
+    </>
+  );
+}

--- a/components/modal/Modal.tsx
+++ b/components/modal/Modal.tsx
@@ -1,0 +1,32 @@
+import { ReactNode } from 'react';
+import { ModalTitle, ModalButton, Input } from '@/components/index';
+import { Portal } from '@/components';
+
+interface ModalMainProps {
+  children?: ReactNode;
+  onSubmit: () => void;
+  isOpen: boolean;
+}
+
+function ModalMain({ children, isOpen, onSubmit }: ModalMainProps) {
+  return (
+    <Portal selector="portal" show={isOpen}>
+      <div className="fixed top-[0px] left-[0px] flex-center bg-black/50 w-screen h-screen">
+        <form
+          onSubmit={onSubmit}
+          className="fixed flex flex-col bg-white rounded-md gap-28pxr w-540pxr py-28pxr px-28pxr mobile:w-327pxr"
+        >
+          {children}
+        </form>
+      </div>
+    </Portal>
+  );
+}
+
+const Modal = Object.assign(ModalMain, {
+  Title: ModalTitle,
+  Button: ModalButton,
+  Input,
+});
+
+export default Modal;

--- a/components/modal/Modal.tsx
+++ b/components/modal/Modal.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from 'react';
-import { ModalTitle, ModalButton, Input } from '@/components/index';
+import { ModalTitle, ModalButton, Input, ColorChips } from '@/components/index';
 import { Portal } from '@/components';
 
 interface ModalMainProps {
@@ -27,6 +27,7 @@ const Modal = Object.assign(ModalMain, {
   Title: ModalTitle,
   Button: ModalButton,
   Input,
+  ColorChips,
 });
 
 export default Modal;

--- a/components/modal/ModalButton.tsx
+++ b/components/modal/ModalButton.tsx
@@ -1,0 +1,30 @@
+import { ReactNode } from 'react';
+import { Button } from '@/components/index';
+
+interface ModalButtonProps {
+  children: ReactNode;
+  disabled: boolean;
+  onCancle: () => void;
+}
+
+export default function ModalButton({
+  children,
+  onCancle,
+  disabled,
+}: ModalButtonProps) {
+  return (
+    <div className="flex justify-end w-full gap-12pxr">
+      <Button variant="modal" size="modal" onClick={onCancle}>
+        취소
+      </Button>
+      <Button
+        disabled={disabled}
+        variant={disabled ? 'inactive' : 'primary'}
+        size="modal"
+        type="submit"
+      >
+        {children}
+      </Button>
+    </div>
+  );
+}

--- a/components/modal/ModalButton.tsx
+++ b/components/modal/ModalButton.tsx
@@ -4,17 +4,17 @@ import { Button } from '@/components/index';
 interface ModalButtonProps {
   children: ReactNode;
   disabled: boolean;
-  onCancle: () => void;
+  onCancel: () => void;
 }
 
 export default function ModalButton({
   children,
-  onCancle,
+  onCancel,
   disabled,
 }: ModalButtonProps) {
   return (
     <div className="flex justify-end w-full gap-12pxr">
-      <Button variant="modal" size="modal" onClick={onCancle}>
+      <Button variant="modal" size="modal" onClick={onCancel}>
         취소
       </Button>
       <Button

--- a/components/modal/ModalTitle.tsx
+++ b/components/modal/ModalTitle.tsx
@@ -1,0 +1,13 @@
+import { ReactNode } from 'react';
+
+interface ModalTitleProps {
+  children: ReactNode;
+}
+
+export default function ModalTitle({ children }: ModalTitleProps) {
+  return (
+    <div className={`font-bold text-24pxr my-4pxr mobile:text-20pxr`}>
+      {children}
+    </div>
+  );
+}

--- a/components/modal/Portal.tsx
+++ b/components/modal/Portal.tsx
@@ -1,0 +1,16 @@
+import { ReactNode, useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
+
+interface PortalProps {
+  children: ReactNode;
+  selector: string;
+  show: boolean;
+}
+
+export default function Portal({ children, selector, show }: PortalProps) {
+  const ref = useRef<Element | null>(null);
+  useEffect(() => {
+    ref.current = document.getElementById(selector);
+  }, [selector]);
+  return show && ref.current ? createPortal(children, ref.current) : null;
+}

--- a/components/modal/data/usePostDashboard.ts
+++ b/components/modal/data/usePostDashboard.ts
@@ -1,0 +1,31 @@
+import { useCallback } from 'react';
+import { axiosAuthInstance } from '@/utils';
+import { useAsync } from '@/hooks/useAsync';
+import { Dashboard } from '../type';
+
+interface PostDashboardBody {
+  title: string;
+  color: string;
+}
+
+const usePostDashboard = ({ title, color }: PostDashboardBody) => {
+  const postDashboard = useCallback(
+    () =>
+      axiosAuthInstance.post<{ data: Dashboard }>('dashboards', {
+        title,
+        color,
+      }),
+    [title, color]
+  );
+
+  const { execute, loading, error, data } = useAsync(postDashboard, true);
+
+  return {
+    execute,
+    loading,
+    error,
+    data,
+  };
+};
+
+export default usePostDashboard;

--- a/components/modal/type.ts
+++ b/components/modal/type.ts
@@ -1,0 +1,9 @@
+export interface Dashboard {
+  id: number;
+  title: 'string';
+  color: 'string';
+  createdAt: string;
+  updatedAt: string;
+  createdByMe: boolean;
+  userId: number;
+}

--- a/components/sign/form/LoginForm.tsx
+++ b/components/sign/form/LoginForm.tsx
@@ -6,7 +6,7 @@ import {
   VALID_EMAIL_REG,
   VALID_PASSWORD_REG,
 } from '../constants';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { Button, PasswordInput, Input } from '@/components';
 import { useLogin, useTokenRedirect } from '../data';
 
@@ -16,7 +16,7 @@ export default function LoginForm() {
     handleSubmit,
     watch,
     setError,
-    formState: { errors, isValid },
+    formState: { isValid },
   } = useForm({
     defaultValues: { email: '', password: '' },
     mode: 'onBlur',
@@ -29,8 +29,6 @@ export default function LoginForm() {
     email: watch('email'),
     password: watch('password'),
   });
-
-  const watchedFields = watch(['email', 'password']);
 
   useTokenRedirect(data?.accessToken);
 

--- a/components/sign/form/SignUpForm.tsx
+++ b/components/sign/form/SignUpForm.tsx
@@ -20,7 +20,7 @@ export default function SignUpForm() {
     control,
     handleSubmit,
     watch,
-    formState: { errors, isValid },
+    formState: { isValid },
   } = useForm({
     defaultValues: {
       email: '',
@@ -32,14 +32,6 @@ export default function SignUpForm() {
     mode: 'onBlur',
     reValidateMode: 'onBlur',
   });
-
-  const watchedFields = watch([
-    'email',
-    'password',
-    'confirmedPassword',
-    'nickname',
-    'termsOfUse',
-  ]);
 
   const {
     execute: signUp,

--- a/hooks/useToggle.ts
+++ b/hooks/useToggle.ts
@@ -1,0 +1,12 @@
+import { useCallback, useState } from 'react';
+interface useBooleanOutput {
+  isOn: boolean;
+  toggle: () => void;
+}
+
+export default function useToggle(defaultValue?: boolean): useBooleanOutput {
+  const [isOn, setIsOn] = useState<boolean>(!!defaultValue);
+  const toggle = useCallback(() => setIsOn((prev) => !prev), []);
+
+  return { isOn, toggle };
+}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "zustand": "^4.4.7"
   },
   "devDependencies": {
+    "@hookform/devtools": "^4.3.1",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,4 +1,4 @@
-import { Html, Head, Main, NextScript } from 'next/document'
+import { Html, Head, Main, NextScript } from 'next/document';
 
 export default function Document() {
   return (
@@ -6,8 +6,9 @@ export default function Document() {
       <Head />
       <body>
         <Main />
+        <div id="portal" />
         <NextScript />
       </body>
     </Html>
-  )
+  );
 }


### PR DESCRIPTION
## 🛠️주요 변경 사항
- 모달 구현을 위한 Portal, Modal, Modal Title, Modal Button 기능을 구현했습니다.
- 대시보드 생성 모달 CreateDashboardModal 컴포넌트를 구현했습니다.
    - 이름 값, 색상 선택이 이루어져야 생성 버튼이 활성화 됩니다.
    - 취소버튼을 누르면 창이 닫힙니다.
    - 생성버튼을 누르면 submit 된 후 창이 닫힙니다.
- toggle 기능을 하는 useToggle 커스텀 훅을 만들었습니다.

## 📣리뷰어에게 하고싶은 말
- react hook form을 커스텀 훅으로 만드려고 했는데, 바로 리액트 훅 폼 자체가 이미 커스텀훅과 같은 기능을 하는 것 같아 우선 놔뒀습니다.
- 우선 최대한 유연하게 만드려고 노력했습니다. 다른 모달창 구현하면서 필요한 부분 추가하거나 재사용성 확대를 위해 고민해봐야할 것 같아요!

## 🖼️스크린샷(선택)
![대시보드 생성 모달](https://github.com/codeit-sprint-team1/Taskify/assets/144652458/984dc92a-fcc6-4860-b165-8d4974e56407)

## ❗관련이슈
- close #18 
