### PR TITLE
feat: 로그인/회원가입 페이지 디자인 적용

### DIFF
--- a/components/common/Button.tsx
+++ b/components/common/Button.tsx
@@ -85,7 +85,7 @@ function Button({
       break;
     }
     case 'sign': {
-      combinedClassName += ' py-14pxr px-236pxr w-full text-18pxr ';
+      combinedClassName += ' p-14pxr w-full h-50pxr text-18pxr mt-4pxr';
       break;
     }
   }

--- a/components/common/Input.tsx
+++ b/components/common/Input.tsx
@@ -48,7 +48,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
             onBlur={onBlur}
             className={`block w-full rounded-md border border-solid ${
               hasError ? 'border-red' : 'border-gray30'
-            } px-16pxr py-15pxr tablet:text-16pxr mobile:text-14pxr text-gray70 placeholder:text-gray40 focus:border-violet outline-0`}
+            } px-16pxr py-15pxr tablet:text-16pxr mobile:text-14pxr text-gray70 placeholder:text-gray40 focus:border-violet outline-0 h-50pxr`}
           />
         </div>
         {hasError && (

--- a/components/common/PasswordInput.tsx
+++ b/components/common/PasswordInput.tsx
@@ -32,6 +32,7 @@ const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(
         <button
           type="button"
           onClick={() => setIsPasswordVisible(!isPasswordVisible)}
+          className="absolute right-10pxr top-47pxr"
         >
           {isPasswordVisible ? (
             <Image src={EyeOnIcon} alt="비밀번호 보이기 아이콘" />

--- a/components/sign/footer/SignFooter.tsx
+++ b/components/sign/footer/SignFooter.tsx
@@ -8,11 +8,13 @@ export default function SignFooter() {
   const isLoginPage = router.pathname === '/login';
 
   return (
-    <div>
+    <div className="flex-center mt-20pxr gap-10pxr">
       <span>{isLoginPage ? LINK_TEXT.isNotMember : LINK_TEXT.isMember}</span>
-      <Link href={isLoginPage ? ROUTE.signUp : ROUTE.login}>
-        {isLoginPage ? BUTTON_TEXT.goToSignUp : BUTTON_TEXT.goToLogin}
-      </Link>
+      <div className="text-violet underline underline-offset-4 leading-30pxr">
+        <Link href={isLoginPage ? ROUTE.signUp : ROUTE.login}>
+          {isLoginPage ? BUTTON_TEXT.goToSignUp : BUTTON_TEXT.goToLogin}
+        </Link>
+      </div>
     </div>
   );
 }

--- a/components/sign/form/LoginForm.tsx
+++ b/components/sign/form/LoginForm.tsx
@@ -51,7 +51,10 @@ export default function LoginForm() {
   }, [error, setError]);
 
   return (
-    <form onSubmit={handleSubmit(login)}>
+    <form
+      onSubmit={handleSubmit(login)}
+      className="w-520pxr flex flex-col gap-16pxr mobile:mx-12pxr mobile:w-350pxr "
+    >
       <div>
         <label>이메일</label>
         <Controller
@@ -74,7 +77,7 @@ export default function LoginForm() {
           )}
         />
       </div>
-      <div>
+      <div className="relative">
         <label>비밀번호</label>
         <Controller
           control={control}

--- a/components/sign/form/SignUpForm.tsx
+++ b/components/sign/form/SignUpForm.tsx
@@ -55,8 +55,12 @@ export default function SignUpForm() {
   }, [data]);
 
   return (
-    <form onSubmit={handleSubmit(signUp)}>
+    <form
+      onSubmit={handleSubmit(signUp)}
+      className="w-520pxr flex flex-col gap-16pxr mobile:mx-12pxr mobile:w-350pxr"
+    >
       <div>
+        <label className="font-small mb-8pxr">이메일</label>
         <Controller
           control={control}
           name="email"
@@ -70,7 +74,6 @@ export default function SignUpForm() {
           render={({ field, fieldState }) => (
             <Input
               {...field}
-              label="이메일"
               placeholder={PLACEHOLDER.email}
               hasError={Boolean(fieldState.error) || isEmailAlreadyExist}
               helperText={
@@ -83,6 +86,7 @@ export default function SignUpForm() {
         />
       </div>
       <div>
+        <label className="font-small mb-8pxr">닉네임</label>
         <Controller
           control={control}
           name="nickname"
@@ -100,7 +104,6 @@ export default function SignUpForm() {
           render={({ field, fieldState }) => (
             <Input
               {...field}
-              label="닉네임"
               placeholder={PLACEHOLDER.nickname}
               hasError={Boolean(fieldState.error)}
               helperText={fieldState.error?.message}
@@ -108,7 +111,8 @@ export default function SignUpForm() {
           )}
         />
       </div>
-      <div>
+      <div className="relative">
+        <label className="font-small mb-8pxr">비밀번호</label>
         <Controller
           control={control}
           name="password"
@@ -122,7 +126,6 @@ export default function SignUpForm() {
           render={({ field, fieldState }) => (
             <PasswordInput
               {...field}
-              label="비밀번호"
               hasEyeIcon
               placeholder={PLACEHOLDER.password}
               hasError={Boolean(fieldState.error)}
@@ -131,7 +134,8 @@ export default function SignUpForm() {
           )}
         />
       </div>
-      <div>
+      <div className="relative">
+        <label className="font-small mb-8pxr">비밀번호 확인</label>
         <Controller
           control={control}
           name="confirmedPassword"
@@ -148,7 +152,6 @@ export default function SignUpForm() {
           render={({ field, fieldState }) => (
             <PasswordInput
               {...field}
-              label="비밀번호 확인"
               hasEyeIcon
               placeholder={PLACEHOLDER.confirmedPassword}
               hasError={Boolean(fieldState.error)}
@@ -157,25 +160,27 @@ export default function SignUpForm() {
           )}
         />
       </div>
-      <Controller
-        control={control}
-        name="termsOfUse"
-        rules={{
-          required: true,
-        }}
-        render={({ field: { onChange, onBlur, value, ref } }) => (
-          <div>
-            <input
-              type="checkbox"
-              onChange={onChange}
-              onBlur={onBlur}
-              checked={value}
-              ref={ref}
-            />
-            {TERMS_OF_USE_MESSAGE}
-          </div>
-        )}
-      />
+      <div>
+        <Controller
+          control={control}
+          name="termsOfUse"
+          rules={{
+            required: true,
+          }}
+          render={({ field: { onChange, onBlur, value, ref } }) => (
+            <div className="flex gap-5pxr">
+              <input
+                type="checkbox"
+                onChange={onChange}
+                onBlur={onBlur}
+                checked={value}
+                ref={ref}
+              />
+              <p className="mt-8pxr mb-5pxr">{TERMS_OF_USE_MESSAGE}</p>
+            </div>
+          )}
+        />
+      </div>
       <Button
         type="submit"
         disabled={!isValid}

--- a/components/sign/header/SignHeader.tsx
+++ b/components/sign/header/SignHeader.tsx
@@ -10,13 +10,21 @@ export default function SignHeader() {
   const isLoginPage = router.pathname === '/login';
 
   return (
-    <div>
-      <Link href="/">
-        <Image src={mainImage} alt="메인 이미지" />
-        <Image src={logo} alt="로고 이미지" />
+    <div className="flex flex-col flex-initial gap-30pxr mb-38pxr">
+      <Link href="/" className="self-end">
+        <Image
+          src={mainImage}
+          alt="메인 이미지"
+          className="w-165pxr h-190pxr mobile:w-115pxr mobile:h-132pxr"
+        />
       </Link>
-      <div>
-        <span>
+      <div className="flex flex-col items-center">
+        <Image
+          src={logo}
+          alt="로고 이미지"
+          className="w-200pxr mobile:w-139pxr"
+        />
+        <span className="text-20pxr font-medium">
           {isLoginPage ? WELLCOME_MESSAGE.login : WELLCOME_MESSAGE.signup}
         </span>
       </div>

--- a/components/sign/header/SignHeader.tsx
+++ b/components/sign/header/SignHeader.tsx
@@ -15,14 +15,14 @@ export default function SignHeader() {
         <Image
           src={mainImage}
           alt="메인 이미지"
-          className="w-165pxr h-190pxr mobile:w-115pxr mobile:h-132pxr"
+          className="w-115px h-133pxr mobile:w-80pxr mobile:h-92pxr"
         />
       </Link>
       <div className="flex flex-col items-center">
         <Image
           src={logo}
           alt="로고 이미지"
-          className="w-200pxr mobile:w-139pxr"
+          className="w-140pxr mobile:w-97pxr"
         />
         <span className="text-20pxr font-medium">
           {isLoginPage ? WELLCOME_MESSAGE.login : WELLCOME_MESSAGE.signup}

--- a/page-layout/SignLayout.tsx
+++ b/page-layout/SignLayout.tsx
@@ -1,3 +1,4 @@
+import { useRouter } from 'next/router';
 import { ReactNode } from 'react';
 
 interface SignInLayoutProps {
@@ -11,8 +12,15 @@ export default function SignLayout({
   form,
   footer,
 }: SignInLayoutProps) {
+  const router = useRouter();
+  const isLoginPage = router.pathname === '/login';
+
   return (
-    <main className="bg-gray10 overflow-y-scroll flex-center h-full py-150pxr ">
+    <main
+      className={`bg-gray10 overflow-y-scroll flex-center ${
+        isLoginPage ? 'h-screen' : 'h-full py-50pxr'
+      }`}
+    >
       <section className="flex-center flex-col ">
         {header}
         {form}

--- a/page-layout/SignLayout.tsx
+++ b/page-layout/SignLayout.tsx
@@ -12,12 +12,12 @@ export default function SignLayout({
   footer,
 }: SignInLayoutProps) {
   return (
-    <div>
-      <div>
+    <main className="bg-gray10 h-full overflow-y-scroll flex-center py-150pxr">
+      <section className="flex-center flex-col ">
         {header}
         {form}
         {footer}
-      </div>
-    </div>
+      </section>
+    </main>
   );
 }

--- a/page-layout/SignLayout.tsx
+++ b/page-layout/SignLayout.tsx
@@ -12,7 +12,7 @@ export default function SignLayout({
   footer,
 }: SignInLayoutProps) {
   return (
-    <main className="bg-gray10 h-full overflow-y-scroll flex-center py-150pxr">
+    <main className="bg-gray10 overflow-y-scroll flex-center h-full py-150pxr ">
       <section className="flex-center flex-col ">
         {header}
         {form}

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,13 +1,13 @@
-import { Html, Head, Main, NextScript } from 'next/document'
+import { Html, Head, Main, NextScript } from 'next/document';
 
 export default function Document() {
   return (
-    <Html lang="en">
+    <Html lang="ko">
       <Head />
       <body>
         <Main />
         <NextScript />
       </body>
     </Html>
-  )
+  );
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -8,6 +8,8 @@
     font-size: 16px;
     font-weight: 400;
     color: #000000;
+    height: 100%;
+    min-height: 100%;
   }
 }
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -17,6 +17,7 @@ const config: Config = {
     './pages/**/*.{js,ts,jsx,tsx,mdx}',
     './components/**/*.{js,ts,jsx,tsx,mdx}',
     './app/**/*.{js,ts,jsx,tsx,mdx}',
+    './page-layout/**/*.{js,ts,jsx,tsx,mdx}',
   ],
   theme: {
     spacing: {


### PR DESCRIPTION
## 🛠️주요 변경 사항
- 로그인/회원가입 페이지 디자인 적용
- 반응형 적용 
- 로그인버튼 패딩값이 커서 반응형일 때 글씨가 찌뿌짜부되어서 수정했슴다.
- 폼 컴포넌트에 label 다시 달았습니다.

## 📣리뷰어에게 하고싶은 말

- 테일윈드 너란 녀석

## 🖼️스크린샷(선택)
![스크린샷 2023-12-21 오후 9 14 39](https://github.com/codeit-sprint-team1/Taskify/assets/120437902/a0f403ff-4df6-4996-8ac2-dc138a97991d)

- html 세로 사이즈가 main태그 padding값 이상이 되면 배경색이 적용이 안됩니다ㅜㅜ
해결방법 아시는분 코멘트달아주세용.
signLayout에 h-screen 적용했었는데 signup페이지에서는 로고가 짤리더라구요...그래서 h-full로 일단 바꿨습니다.



## ❗관련이슈
- close #41 close #42 
