### PR TITLE
Fix/error

### DIFF
--- a/components/dashboard/header/Header.tsx
+++ b/components/dashboard/header/Header.tsx
@@ -4,12 +4,6 @@ import { Profile } from '@/components';
 import crownIcon from '@/public/icons/crown-icon.svg';
 import { useUserInfo } from '@/store/memos';
 
-export interface MyDashboardHeaderProps {
-  dashboard: {
-    title: string;
-    createdByMe: boolean;
-  };
-}
 export interface DashboardHeaderProps {
   dashboard: {
     id: number;
@@ -21,7 +15,6 @@ export interface DashboardHeaderProps {
 
 type HeaderProps = {
   dashboard: {
-    id?: number;
     title: string;
     createdByMe: boolean;
   };
@@ -33,10 +26,12 @@ export default function Header({ dashboard, children }: HeaderProps) {
   const [profileImage, setProfileImage] = useState<string | null>('');
 
   const { userInfo } = useUserInfo();
+
   useEffect(() => {
     setNickname(userInfo.nickname);
     setProfileImage(userInfo.profileImageUrl);
   }, []);
+
   return (
     <header className="flex items-center justify-end border-b desktop:justify-between mobile:justify-end h-70pxr desktop:pl-40pxr desktop:pr-80pxr px-40pxr mobile:px-12pxr border-b-gray30">
       <div className="hidden desktop:flex desktop:items-center gap-8pxr ">

--- a/components/dashboard/sidebar/DashboardSidebar.tsx
+++ b/components/dashboard/sidebar/DashboardSidebar.tsx
@@ -85,7 +85,7 @@ export default function DashboardSidebar({
           <CreateDashboardButton />
         </div>
         <div className="flex flex-col w-full gap-3pxr">
-          {dashboardList.map((dashboard) => {
+          {dashboardList?.map((dashboard) => {
             return (
               <DashboardListItem
                 key={dashboard.id}

--- a/components/modal/create-dashboard/CreateDashboardModal.tsx
+++ b/components/modal/create-dashboard/CreateDashboardModal.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import usePostDashboards from '../data/usePostDashboards';
 import { useDashboardList } from '@/store/memos/useDashboardList';
-
+import { ColorChips, ModalButton } from '@/components';
 export interface ModalProps {
   isOpen: boolean;
   onCancel: () => void;
@@ -26,9 +26,10 @@ export default function CreateDashboardModal({ isOpen, onCancel }: ModalProps) {
 
   const watchInput = watch('title');
 
-  const onSelect = (value: string) => {
-    setColor(value);
+  const onSelect = (color: string) => {
+    setColor(color);
   };
+
   const handleCancel = () => {
     reset();
     setColor('');
@@ -77,13 +78,13 @@ export default function CreateDashboardModal({ isOpen, onCancel }: ModalProps) {
             )}
           />
         </div>
-        <Modal.ColorChips onSelect={onSelect} />
-        <Modal.Button
+        <ColorChips onSelect={onSelect} />
+        <ModalButton
           disabled={!isValid || color === '' || loading}
           onCancel={handleCancel}
         >
           생성
-        </Modal.Button>
+        </ModalButton>
       </Modal>
     </>
   );

--- a/pages/mydashboard/index.tsx
+++ b/pages/mydashboard/index.tsx
@@ -1,12 +1,10 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { useDashboardList } from '@/store/memos/useDashboardList';
 import DashboardLayout from '@/page-layout/DashboardLayout';
 import { Header, DashboardSidebar } from '@/components';
 import useGetDashboards from '@/components/dashboard/data/useGetDashboards';
-import { Dashboards } from '@/types/dashboards';
 
 export default function MyDashboardPage() {
-  const [dashboardData, setDashboardData] = useState<Dashboards[]>([]);
   const { dashboards } = useGetDashboards();
   const { dashboardList, setDashboardList } = useDashboardList();
 
@@ -14,23 +12,19 @@ export default function MyDashboardPage() {
     setDashboardList(dashboards);
   }, [dashboards]);
 
-  useEffect(() => {
-    setDashboardData(dashboardList);
-  }, [dashboardList]);
-
   const dashboard = {
     title: '내 대시보드',
     createdByMe: false,
   };
 
-  if (dashboardData?.length === 0) return;
+  if (dashboards === undefined) return;
 
   return (
     <>
       <DashboardLayout
         header={<Header dashboard={dashboard} />}
         main={'main'}
-        sidebar={<DashboardSidebar dashboardList={dashboardData} />}
+        sidebar={<DashboardSidebar dashboardList={dashboardList} />}
       ></DashboardLayout>
     </>
   );

--- a/pages/mydashboard/index.tsx
+++ b/pages/mydashboard/index.tsx
@@ -1,30 +1,36 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useDashboardList } from '@/store/memos/useDashboardList';
 import DashboardLayout from '@/page-layout/DashboardLayout';
 import { Header, DashboardSidebar } from '@/components';
-import useGetDashboardList from '@/components/dashboard/data/useGetDashboards';
+import useGetDashboards from '@/components/dashboard/data/useGetDashboards';
+import { Dashboards } from '@/types/dashboards';
 
 export default function MyDashboardPage() {
-  const { dashboards } = useGetDashboardList();
+  const [dashboardData, setDashboardData] = useState<Dashboards[]>([]);
+  const { dashboards } = useGetDashboards();
   const { dashboardList, setDashboardList } = useDashboardList();
 
   useEffect(() => {
     setDashboardList(dashboards);
   }, [dashboards]);
 
+  useEffect(() => {
+    setDashboardData(dashboardList);
+  }, [dashboardList]);
+
   const dashboard = {
     title: '내 대시보드',
     createdByMe: false,
   };
 
-  if (!dashboardList) return;
+  if (dashboardData?.length === 0) return;
 
   return (
     <>
       <DashboardLayout
         header={<Header dashboard={dashboard} />}
-        main={<div>main</div>}
-        sidebar={<DashboardSidebar dashboardList={dashboardList} />}
+        main={'main'}
+        sidebar={<DashboardSidebar dashboardList={dashboardData} />}
       ></DashboardLayout>
     </>
   );


### PR DESCRIPTION
## 🛠️주요 변경 사항
- 2가지 에러를 해결했습니다
- 1번. Modal.Button / Modal.ColorChips import 오류
    - 현상: Modal 컴파운드 컴포넌트에서 컴포넌트 내부 요소들을 Object로 묶어서 사용 중이었는데, 여기서 type is invalid 에러가 떴습니다.
    - 해결: ⇨ Modal.Button, Modal.ColorChips 대신 직접 import 해서 <ModalButton />, <ColorChips/> 컴포넌트 바로 삽입하여 해결
    - 풀리지 않는 의문: Modal.Title이나 Modal.Input은 잘 되는데 왜 저 컴포넌트 들에서만 해당 오류가 발생하는지 도통 모르겠습니다...
    - 여전히 남은 문제: 제 해결방식은 컴파운트 컴포넌트 활용을 해치는(?) 방식이라 다른 해결 방식을 고민해봐야 할 것 같아요 ㅠㅠ
- 2번. 내 대시보드(/mydashboard) 페이지의 Hydration 오류
    - @Accept77 진수님께서 오류를 먼저 발견하시고 해결책을 알려주셨습니다. 🙇‍♀️👍
    - 현상: 대시보드 목록에 persist를 사용한 후부터 해당 오류가 발생
        - persist로 감싸진 상태를 초기setting 하는 페이지에서 새로고침 시 문제가 발생.
        - 현재 초기 세팅 단계
            - 1️⃣ useGetDashboards()로 Dashboards 목록을 불러옴(비동기)
                - 이때 첫 **Dashboards 값은 undefined**.
            - 2️⃣ useDashboardList에서 전역 상태(DashboardList)와 세터함수(setDashbooardList)를 받아옴.(비동기)
                - 이때 **전역 상태는 이전에 저장해 둔 배열 그대로 가져옴**
            - 3️⃣ **`if (dashboardList?.length === 0) return;`을 만나 return 될 것 같지만 안 됨**. 왜냐면 이전에 저장해 둔 상태가 보존되어있기 때문에 length가 0이 아님 => ⭐️SSR에서는 이전에 저장된 배열로 DOM tree가 그려짐
            - 4️⃣ useEffect문 **setDashbooardList로 전역상태 업데이트** - undefined => ⭐️브라우저에서는 새로 저장된 undefined로 아예 안그려짐.
    - 예상원인: 위 3, 4번으로 인한 차이 때문 
    - ⇨ 해결1: 전역상태를 초기 세팅하자마자 해당 값을 사용하는 것이 아닌, 초기 세팅한 후 받은 값을 다시 페이지의 state에 담아 사용.
    - ⇨ 해결2: useGetDashboard로 불러오는 값인 dashboards가 undefined 일 때 return 하도록 함
        - `if (dashboardList?.length === 0) return;` ⇨ `if (dashboards === undefined) return;`

## 📣리뷰어에게 하고싶은 말
- 오늘 에러와의 혈투 벌이신 진수님께 존경을 표합니다👏
- 또 마주칠 수 있는 에러라서 자세하게 적어봤습니다.
- 혹시 제가 생각한 원인과 해결방법이 잘 못 되었거나, 더 나은 방법이 있다면 말씀 부탁드립니다.

## 🖼️스크린샷(선택)
1번. Modal.Button / Modal.ColorChips import 오류
```
Warning: React.jsx: type is invalid -- expected a string (for built-in components) or a class/function (for composite components) but got: undefined. You likely forgot to export your component from the file it's defined in, or you might have mixed up default and named imports.

Check your code at CreateDashboardModal.tsx:80.
```

2번. 내 대시보드(/mydashboard) 페이지의 Hydration 오류

<img width="695" alt="Screen Shot 2023-12-30 at 01 14 56" src="https://github.com/codeit-sprint-team1/Taskify/assets/144652458/af3d0fbb-3f10-46b1-ad62-a50a7fe583b2">



## ❗관련이슈
