### PR TITLE
feat: 컬럼 삭제 확인 모달 추가

### DIFF
--- a/components/dashboard/data/useDeleteColumns.tsx
+++ b/components/dashboard/data/useDeleteColumns.tsx
@@ -1,0 +1,25 @@
+import { useAsync } from '@/hooks/useAsync';
+import { axiosAuthInstance } from '@/utils';
+import { useCallback } from 'react';
+
+const useDeleteColumns = (columnId: number) => {
+  const deleteColumns = useCallback(
+    () => axiosAuthInstance.delete(`columns/${columnId}`),
+    [columnId]
+  );
+
+  const { execute, loading, error, data, status } = useAsync(
+    deleteColumns,
+    true
+  );
+
+  return {
+    execute,
+    loading,
+    error,
+    data,
+    status,
+  };
+};
+
+export default useDeleteColumns;

--- a/components/dashboard/data/useGetDashboards.tsx
+++ b/components/dashboard/data/useGetDashboards.tsx
@@ -3,7 +3,7 @@ import { axiosAuthInstance } from '@/utils';
 import { useCallback } from 'react';
 import { Dashboards } from '@/types/dashboards';
 
-export default function useGetDashboards() {
+const useGetDashboards = () => {
   const getDashboards = useCallback(
     () =>
       axiosAuthInstance.get(
@@ -24,4 +24,6 @@ export default function useGetDashboards() {
     totalCount,
     dashboards,
   };
-}
+};
+
+export default useGetDashboards;

--- a/components/modal/Modal.tsx
+++ b/components/modal/Modal.tsx
@@ -1,4 +1,4 @@
-import { EventHandler, FormEvent, ReactNode } from 'react';
+import { FormEvent, ReactNode } from 'react';
 import {
   ModalTitle,
   ModalButton,

--- a/components/modal/Modal.tsx
+++ b/components/modal/Modal.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { EventHandler, FormEvent, ReactNode } from 'react';
 import {
   ModalTitle,
   ModalButton,
@@ -11,7 +11,7 @@ import { Portal } from '@/components';
 
 interface ModalMainProps {
   children?: ReactNode;
-  onSubmit: () => void;
+  onSubmit: (() => void) | ((e: FormEvent) => void);
   isOpen: boolean;
 }
 

--- a/components/modal/delete-column/DeleteColumnConfirmModal.tsx
+++ b/components/modal/delete-column/DeleteColumnConfirmModal.tsx
@@ -1,0 +1,44 @@
+import { FormEvent, useEffect } from 'react';
+import { Modal, ModalButton } from '@/components';
+import useDeleteColumns from '@/components/dashboard/data/useDeleteColumns';
+import { notify } from '@/components/common/Toast';
+import { DeleteColumnModalProps } from './DeleteColumnModal';
+
+export default function DeleteColumnConfirmModal({
+  isOpen,
+  onCancel,
+  columnId,
+}: DeleteColumnModalProps) {
+  const {
+    execute: deleteColumns,
+    loading,
+    error,
+    status,
+  } = useDeleteColumns(columnId);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    await deleteColumns();
+  };
+
+  useEffect(() => {
+    if (loading) return;
+    if (error) {
+      notify({ type: 'error', text: error.response.data.message });
+    } else if (status === 204) {
+      notify({ type: 'success', text: '컬럼이 삭제됐습니다 🗑' });
+    }
+    onCancel();
+  }, [loading]);
+
+  return (
+    <Modal onSubmit={handleSubmit} isOpen={isOpen}>
+      <div className="pt-80pxr pb-17pxr text-center text-18pxr font-medium">
+        컬럼의 모든 카드가 삭제됩니다.
+      </div>
+      <ModalButton disabled={loading} onCancel={onCancel}>
+        삭제
+      </ModalButton>
+    </Modal>
+  );
+}

--- a/hooks/useAsync.ts
+++ b/hooks/useAsync.ts
@@ -9,14 +9,17 @@ export const useAsync = <T>(
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<null | any>(null);
   const [data, setData] = useState<null | T>(null);
+  const [status, setStatus] = useState<null | number>(null);
 
   const execute = async () => {
     setLoading(true);
     setError(null);
     setData(null);
+    setStatus(null);
     try {
       const response = await asyncFunction();
       setData(response?.data ?? null);
+      setStatus(response?.status ?? null);
       return response;
     } catch (error) {
       setError(error);
@@ -31,5 +34,5 @@ export const useAsync = <T>(
     }
   }, [lazyMode, deps]);
 
-  return { execute, loading, error, data };
+  return { execute, loading, error, data, status };
 };


### PR DESCRIPTION
## 🛠️주요 변경 사항
- 컬럼 삭제하기 누르면 나오는 '카드 모두 삭제됩니다' 모달 구현

## 📣리뷰어에게 하고싶은 말
- @wecaners 이거 복제해서, 삭제 API랑 멘트만 바꿔서 사용하시면 될 것 같아요!
- 추후 컬럼 수정 모달 '삭제하기' 버튼에 들어갈 내용
```ts
import DeleteColumnConfirmModal from '@/components/modal/delete-column/DeleteColumnConfirmModal';
import useToggle from '@/hooks/useToggle';
export default function DeleteColumnModal {
  const { isOn, toggle } = useToggle(false);
  return (
    <div>
      <DeleteColumnConfirmModal
        isOpen={isOn}
        onCancel={toggle}
        columnId={columnId}
      />
      <button onClick={toggle}>버튼</button>
    </div>
  );
}

```

## 🖼️스크린샷(선택)

## ❗관련이슈
- close #87 
