### PR TITLE
feat: 컬럼 수정 모달 추가

### DIFF
--- a/components/dashboard/data/usePutColumns.ts
+++ b/components/dashboard/data/usePutColumns.ts
@@ -1,0 +1,31 @@
+import { useCallback } from 'react';
+import { axiosAuthInstance } from '@/utils';
+import { useAsync } from '@/hooks/useAsync';
+import { Columns } from '@/types/columns';
+
+interface UsePutColumnsProps {
+  title: string;
+  columnId: number;
+}
+
+const usePutColumns = ({ title, columnId }: UsePutColumnsProps) => {
+  const putColumns = useCallback(
+    () =>
+      axiosAuthInstance.put<Columns>(`columns/${columnId}`, {
+        title,
+      }),
+    [title, columnId]
+  );
+
+  const { execute, loading, error, data, status } = useAsync(putColumns, true);
+
+  return {
+    execute,
+    loading,
+    error,
+    data,
+    status,
+  };
+};
+
+export default usePutColumns;

--- a/components/index.ts
+++ b/components/index.ts
@@ -16,6 +16,8 @@ export { default as Modal } from './modal/Modal';
 export { default as InviteModal } from './modal/Invite/InviteModal';
 export { default as CreateDashboardModal } from './modal/create-dashboard/CreateDashboardModal';
 export { default as CreateColumnModal } from './modal/create-column/createColumnModal';
+export { default as DeleteColumnConfirmModal } from './modal/edit-column/DeleteColumnConfirmModal';
+export { default as EditColumnModal } from './modal/edit-column/EditColumnModal';
 export { default as InviteListTable } from './boardEdit/InviteListTable';
 export { default as MembersTable } from './boardEdit/MembersTable';
 export { default as NameEditForm } from './boardEdit/NameEditForm';

--- a/components/modal/create-column/createColumnModal.tsx
+++ b/components/modal/create-column/createColumnModal.tsx
@@ -2,7 +2,6 @@ import { Modal } from '@/components';
 import { useEffect, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import usePostColumns from '../data/usePostColumns';
-import { useDashboardList } from '@/store/memos/useDashboardList';
 import { useRouter } from 'next/router';
 
 export interface ModalProps {

--- a/components/modal/create-dashboard/CreateDashboardModal.tsx
+++ b/components/modal/create-dashboard/CreateDashboardModal.tsx
@@ -9,7 +9,7 @@ export interface ModalProps {
   onCancel: () => void;
 }
 
-export interface CreateDashboardModalForm {
+export interface CreateDashboardForm {
   title: string;
 }
 
@@ -21,8 +21,8 @@ export default function CreateDashboardModal({ isOpen, onCancel }: ModalProps) {
     handleSubmit,
     watch,
     reset,
-    formState: { isValid, errors },
-  } = useForm<CreateDashboardModalForm>();
+    formState: { isValid },
+  } = useForm<CreateDashboardForm>();
 
   const watchInput = watch('title');
 

--- a/components/modal/data/usePostColumns.ts
+++ b/components/modal/data/usePostColumns.ts
@@ -3,12 +3,12 @@ import { axiosAuthInstance } from '@/utils';
 import { useAsync } from '@/hooks/useAsync';
 import { Columns } from '@/types/columns';
 
-interface PostColumnsBody {
+interface PostColumnsProps {
   title: string;
   dashboardId: number;
 }
 
-const usePostColumns = ({ title, dashboardId }: PostColumnsBody) => {
+const usePostColumns = ({ title, dashboardId }: PostColumnsProps) => {
   const postColumns = useCallback(
     () =>
       axiosAuthInstance.post<Columns>('columns', {

--- a/components/modal/data/usePostDashboards.ts
+++ b/components/modal/data/usePostDashboards.ts
@@ -3,12 +3,12 @@ import { axiosAuthInstance } from '@/utils';
 import { useAsync } from '@/hooks/useAsync';
 import { Dashboards } from '@/types/dashboards';
 
-interface PostDashboardBody {
+interface PostDashboardProps {
   title: string;
   color: string;
 }
 
-const usePostDashboards = ({ title, color }: PostDashboardBody) => {
+const usePostDashboards = ({ title, color }: PostDashboardProps) => {
   const postDashboards = useCallback(
     () =>
       axiosAuthInstance.post<Dashboards>('dashboards', {

--- a/components/modal/edit-column/DeleteColumnConfirmModal.tsx
+++ b/components/modal/edit-column/DeleteColumnConfirmModal.tsx
@@ -4,14 +4,16 @@ import useDeleteColumns from '@/components/dashboard/data/useDeleteColumns';
 import { notify } from '@/components/common/Toast';
 import { ModalProps } from '../create-dashboard/CreateDashboardModal';
 
-export interface DeleteColumnConfirmModalProps extends ModalProps {
+interface DeleteColumnConfirmModalProps extends ModalProps {
   columnId: number;
+  onClose: () => void;
 }
 
 export default function DeleteColumnConfirmModal({
   isOpen,
   onCancel,
   columnId,
+  onClose,
 }: DeleteColumnConfirmModalProps) {
   const {
     execute: deleteColumns,
@@ -32,7 +34,7 @@ export default function DeleteColumnConfirmModal({
     } else if (status === 204) {
       notify({ type: 'success', text: '컬럼이 삭제됐습니다 🗑' });
     }
-    onCancel();
+    onClose();
   }, [loading]);
 
   return (

--- a/components/modal/edit-column/EditColumnModal.tsx
+++ b/components/modal/edit-column/EditColumnModal.tsx
@@ -1,0 +1,112 @@
+import { useEffect } from 'react';
+import { Controller, useForm } from 'react-hook-form';
+import useToggle from '@/hooks/useToggle';
+import { Modal, ModalButton, DeleteColumnConfirmModal } from '@/components';
+import usePutColumns from '@/components/dashboard/data/usePutColumns';
+import { notify } from '@/components/common/Toast';
+import { ModalProps } from '../create-dashboard/CreateDashboardModal';
+
+export interface EditColumnModalProps extends ModalProps {
+  columnId: number;
+}
+
+interface EditColumnForm {
+  title: string;
+}
+
+export default function EditColumnModal({
+  isOpen,
+  onCancel,
+  columnId,
+}: EditColumnModalProps) {
+  const {
+    control,
+    handleSubmit,
+    watch,
+    reset,
+    formState: { isValid },
+  } = useForm<EditColumnForm>();
+
+  const watchInput = watch('title');
+  const { isOn, toggle } = useToggle(false);
+
+  const handleCancel = () => {
+    reset();
+    onCancel();
+  };
+
+  const {
+    execute: putDashboards,
+    data: response,
+    loading,
+    error,
+    status,
+  } = usePutColumns({
+    title: watch('title'),
+    columnId: columnId,
+  });
+
+  const onSubmit = async () => {
+    await putDashboards();
+  };
+
+  const handleAllClose = () => {
+    handleCancel();
+    toggle();
+  };
+
+  useEffect(() => {
+    if (loading) return;
+    if (error) {
+      notify({ type: 'error', text: error.response.data.message });
+      handleCancel();
+    } else if (status === 200) {
+      notify({ type: 'success', text: '컬럼 이름이 변경됐습니다 🥳' });
+      handleCancel();
+    }
+  }, [error, loading]);
+
+  return (
+    <>
+      <Modal isOpen={isOpen} onSubmit={handleSubmit(onSubmit)}>
+        <Modal.Title>컬럼 관리</Modal.Title>
+        <div className="flex flex-col gap-24pxr">
+          <Controller
+            name="title"
+            control={control}
+            rules={{ required: true }}
+            render={({ field: { ref, onChange }, fieldState }) => (
+              <Modal.Input
+                ref={ref}
+                label="이름"
+                placeholder="변경할 컬럼 이름을 입력해주세요"
+                type="text"
+                value={watchInput}
+                onChange={onChange}
+              />
+            )}
+          />
+        </div>
+        <div className="flex">
+          <button
+            type="button"
+            className="shrink-0 text-14pxr text-gray40 underline underline-offset-4"
+            onClick={toggle}
+          >
+            컬럼 삭제
+          </button>
+
+          <ModalButton disabled={!isValid || loading} onCancel={handleCancel}>
+            변경
+          </ModalButton>
+        </div>
+      </Modal>
+      <DeleteColumnConfirmModal
+        columnId={columnId}
+        isOpen={isOn}
+        onCancel={toggle}
+        onClose={handleAllClose}
+      />
+    </>
+  );
+}

--- a/components/myBoard/DashBoards.tsx
+++ b/components/myBoard/DashBoards.tsx
@@ -34,7 +34,7 @@ function Board({
   };
   const bg = colors[color];
   return (
-    <Link href={`board/${id}`}>
+    <Link href={`dashboard/${id}`}>
       <div className="flex-center justify-between w-full h-70pxr bg-white rounded-lg border border-solid border-gray30 gap-12pxr px-20pxr">
         <div className="flex-center gap-16pxr">
           <div className={`w-8pxr h-8pxr rounded-full ${bg}`}></div>


### PR DESCRIPTION
## 🛠️주요 변경 사항
- 컬럼 수정 모달(EditColumnModal)을 추가했습니다.

## 📣리뷰어에게 하고싶은 말
- 컬럼수정모달 > 삭제모달이 뜰 때 기존 모달 위에 그냥 올려지도록 했습니다.
- 작업하시는 부분과 겹치는게 있을 수 있어 한 번 확인 부탁드립니다! (코드리뷰로 달아두겠습니다.)
- 버튼이랑은 연결하려다가, 오히려 진수님 작업하시는 것과 충돌날 것 같아 하지 않았습니다. (아래는 버튼 연결 예시)

<img width="589" alt="Screen Shot 2024-01-01 at 10 50 19" src="https://github.com/codeit-sprint-team1/Taskify/assets/144652458/95dc9f18-3695-4cec-8b6a-5f65def4c267">

<img width="438" alt="Screen Shot 2024-01-01 at 10 50 00" src="https://github.com/codeit-sprint-team1/Taskify/assets/144652458/375da434-54f6-4578-8192-8053c5b0e6e8">

**별개로 랜덤 컬러 저장이 생각보다 훨씬 공이 많이 들어가는 작업이더군요. 회원가입, 로그인 시 저장과 헤더 프로필 색 반영까지는 구현해두었다가 우선은 잠시 멈춰둔 상태입니다. 아마 이 기능은 내일 논의후 진행 해야할 것 같아요.
1️⃣태그는 가능, 2️⃣프로필 이미지는 엄청 많은 곳을 건드려야해서 논의 필요, 3️⃣컬럼 랜덤색상은 불가능은 아니지만 까다로움. 이 상태입니다!**


## 🖼️스크린샷(선택)
<img width="461" alt="Screen Shot 2024-01-01 at 10 53 08" src="https://github.com/codeit-sprint-team1/Taskify/assets/144652458/f7474aa5-3bd3-4aa8-a0df-5a9708123933">
<img width="461" alt="Screen Shot 2024-01-01 at 10 53 12" src="https://github.com/codeit-sprint-team1/Taskify/assets/144652458/17d9110e-91ca-48c4-95a0-01d4cdbae65b">


## ❗관련이슈
- close #23 


