### PR TITLE
feat: 헤더멤버 hover 및 click 기능 추가

### DIFF
--- a/components/common/ProfileImage.tsx
+++ b/components/common/ProfileImage.tsx
@@ -4,9 +4,15 @@ export interface ProfileImageProps {
   name: string;
   src: string | null;
   size?: string;
+  textDiv?: boolean;
 }
 
-export default function ProfileImage({ name, src, size }: ProfileImageProps) {
+export default function ProfileImage({
+  name,
+  src,
+  size,
+  textDiv,
+}: ProfileImageProps) {
   const divSize = size === 'sm' ? 'w-26pxr h-26pxr' : 'w-38pxr h-38pxr';
   return (
     <div
@@ -15,7 +21,7 @@ export default function ProfileImage({ name, src, size }: ProfileImageProps) {
       {src ? (
         <Image src={src} alt="프로필 이미지" fill />
       ) : (
-        <p className="text-white">{name[0]}</p>
+        <p className="text-white">{textDiv ? name : name[0]}</p>
       )}
     </div>
   );

--- a/components/dashboard/header/HeaderMembers.tsx
+++ b/components/dashboard/header/HeaderMembers.tsx
@@ -96,15 +96,12 @@ export default function HeaderMembers({ dashboardId }: HeaderMembersProps) {
       })}
       <div className="relative group">
         {restMembers?.length !== 0 && (
-          <Link
-            href={`/dashboard/${dashboardId}/edit`}
-            className={`relative block -ml-8pxr mobile:-ml-12pxr`}
-          >
+          <div className={`relative  -ml-8pxr mobile:-ml-12pxr`}>
             <ProfileImage textDiv name={`${restMembers?.length}+`} src="" />
-          </Link>
+          </div>
         )}
 
-        <div className="absolute right-0pxr invisible group-hover:visible p-5pxr bg-violet8 rounded-md mt-5pxr">
+        <div className="absolute right-0pxr invisible group-hover:visible p-5pxr bg-violet8 rounded-md mt-1pxr">
           {restMembers?.map((member) => {
             return (
               <MemberInfoItem
@@ -116,6 +113,14 @@ export default function HeaderMembers({ dashboardId }: HeaderMembersProps) {
               />
             );
           })}
+          {totalCount > 20 && (
+            <Link
+              href={`/dashboard/${dashboardId}/edit`}
+              className="block text-11pxr w-full py-5pxr text-gray50 text-center"
+            >
+              전체 멤버 보기
+            </Link>
+          )}
         </div>
       </div>
     </div>

--- a/components/dashboard/header/HeaderMembers.tsx
+++ b/components/dashboard/header/HeaderMembers.tsx
@@ -86,7 +86,6 @@ export default function HeaderMembers({ dashboardId }: HeaderMembersProps) {
   useEffect(() => {
     setProfileMembers(members.slice(0, numberToMap));
     setRestMembers(members.slice(numberToMap));
-    console.log(totalCount, numberToMap);
   }, [numberToMap, totalCount, dashboardId]);
 
   return (

--- a/components/dashboard/header/HeaderMembers.tsx
+++ b/components/dashboard/header/HeaderMembers.tsx
@@ -2,6 +2,9 @@ import { ProfileImage } from '@/components';
 import useGetMembers from '@/components/boardEdit/data/useGetMembers';
 import { useEffect, useState } from 'react';
 import { Members } from '@/types/members';
+import MemberInfoItem from './MemberInfoItem';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
 
 interface HeaderMembersProps {
   dashboardId: number;
@@ -13,17 +16,26 @@ interface MemberProps {
 }
 
 function Member({ member, index }: MemberProps) {
-  const { id, email, nickname, profileImageUrl } = member;
+  const { email, nickname, profileImageUrl } = member;
   return (
-    <div className={`hover:z-10 ${index !== 0 && '-ml-8pxr mobile:-ml-12pxr'}`}>
-      <ProfileImage name={nickname} src={profileImageUrl} />
-    </div>
+    <>
+      <div
+        className={`relative group hover:z-10 ${
+          index !== 0 && '-ml-8pxr mobile:-ml-12pxr'
+        }`}
+      >
+        <ProfileImage name={nickname} src={profileImageUrl} />
+        <div className="absolute invisible group-hover:visible p-5pxr bg-violet8 rounded-md mt-5pxr">
+          <MemberInfoItem nickname={nickname} email={email} />
+        </div>
+      </div>
+    </>
   );
 }
 
 export default function HeaderMembers({ dashboardId }: HeaderMembersProps) {
-  const [profileMembers, setProfileMembers] = useState<Members[]>();
-  const [restMembers, setRestMembers] = useState<Members[] | null>();
+  const [profileMembers, setProfileMembers] = useState<Members[] | null>(null);
+  const [restMembers, setRestMembers] = useState<Members[] | null>(null);
   const [numberToMap, setNumberToMap] = useState(5);
 
   const {
@@ -39,6 +51,16 @@ export default function HeaderMembers({ dashboardId }: HeaderMembersProps) {
   useEffect(() => {
     getMembers();
   }, [dashboardId]);
+
+  useEffect(() => {
+    if (window.innerWidth < 1023) {
+      if (totalCount <= 3) {
+        setNumberToMap(3);
+      } else {
+        setNumberToMap(2);
+      }
+    }
+  }, []);
 
   useEffect(() => {
     const mediaQuery = window.matchMedia('(max-width:1023px)');
@@ -64,18 +86,38 @@ export default function HeaderMembers({ dashboardId }: HeaderMembersProps) {
   useEffect(() => {
     setProfileMembers(members.slice(0, numberToMap));
     setRestMembers(members.slice(numberToMap));
-  }, [numberToMap, totalCount]);
+    console.log(totalCount, numberToMap);
+  }, [numberToMap, totalCount, dashboardId]);
 
   return (
     <div className="flex items-center h-34pxr">
       {profileMembers?.map((member, index) => {
         return <Member key={member.id} member={member} index={index} />;
       })}
-      {restMembers?.length !== 0 && (
-        <div key={numberToMap - 1} className={`-ml-8pxr mobile:-ml-12pxr`}>
-          <ProfileImage name={`${restMembers?.length}+`} src="" />
+      <div className="relative group">
+        {restMembers?.length !== 0 && (
+          <Link
+            href={`/dashboard/${dashboardId}/edit`}
+            className={`relative block -ml-8pxr mobile:-ml-12pxr`}
+          >
+            <ProfileImage textDiv name={`${restMembers?.length}+`} src="" />
+          </Link>
+        )}
+
+        <div className="absolute right-0pxr invisible group-hover:visible p-5pxr bg-violet8 rounded-md mt-5pxr">
+          {restMembers?.map((member) => {
+            return (
+              <MemberInfoItem
+                showImage
+                key={member.id}
+                nickname={member.nickname}
+                email={member.email}
+                imageUrl={member.profileImageUrl}
+              />
+            );
+          })}
         </div>
-      )}
+      </div>
     </div>
   );
 }

--- a/components/dashboard/header/MemberInfoItem.tsx
+++ b/components/dashboard/header/MemberInfoItem.tsx
@@ -1,0 +1,27 @@
+import { ProfileImage } from '@/components';
+
+interface MemberInfoItemProps {
+  showImage?: boolean;
+  imageUrl?: string;
+  nickname: string;
+  email: string;
+}
+
+export default function MemberInfoItem({
+  showImage,
+  imageUrl,
+  nickname,
+  email,
+}: MemberInfoItemProps) {
+  return (
+    <div className="flex">
+      <div className="shrink">
+        {showImage && <ProfileImage name={nickname} src={imageUrl ?? ''} />}
+      </div>
+      <div className="w-full text-11pxr p-3pxr rounded-sm">
+        <p>{nickname}</p>
+        <p>{email}</p>
+      </div>
+    </div>
+  );
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -46,7 +46,7 @@ const config: Config = {
         gray50: '#787486',
         gray40: '#9fa6b2',
         gray30: '#d9d9d9',
-        gray20: '##EEEEEE',
+        gray20: '#EEEEEE',
         gray10: '#fafafa',
         white: '#ffffff',
         violet: '#5534da',


### PR DESCRIPTION
## 🛠️주요 변경 사항
- 헤더 멤버 목록 프로필 이미지 hover시 해당 프로필이 앞으로 나오며 닉네임과 이메일을 보여줍니다.
- 헤더바에 보이지 않는 멤버는 (+)원형을 hover하면 보입니다. 20명까지 이 리스트에 보이며, 멤버가 20명 이상일 시에는 '전체멤버보기' 버튼이 노출됩니다. 클릭시 대시보드 관리 페이지로 넘어갑니다.

## 📣리뷰어에게 하고싶은 말
- 아직 리팩토링이 필요합니다...
    - 초기데이터 불러왔을때 totalCount값 잘못인식 (서버사이드렌더링 프롭을 사용해야할 것 같은 느낌..?)
    - 아직 matchMedia로 화면 크기 인식하도록 되어있는 부분.

## 🖼️스크린샷(선택)
[프로필이미지]
<img width="482" alt="Screen Shot 2024-01-02 at 15 29 21" src="https://github.com/codeit-sprint-team1/Taskify/assets/144652458/c8106f56-f1bc-42a9-bd4a-f3199b09908d">

[+버튼]
<img width="384" alt="Screen Shot 2024-01-02 at 15 29 49" src="https://github.com/codeit-sprint-team1/Taskify/assets/144652458/b020ac08-4ab9-4ff8-97fe-3719250fab4e">


## ❗관련이슈
- close #85 
