### PR TITLE
feat: 사이드바 타이틀 고정 및 모바일에서 클릭시 오픈되도록 구현

### DIFF
--- a/components/boardEdit/NameEditForm.tsx
+++ b/components/boardEdit/NameEditForm.tsx
@@ -3,7 +3,7 @@ import ColorChips from '../common/ColorChips';
 import { Button, Input } from '..';
 import usePutDashboard from './data/usePutDashboard';
 import { Dashboards } from '@/types/dashboards';
-import { useDashboardList } from '@/store/memos/useDashboardList';
+import { useDashboardList } from '@/store/memos';
 
 interface NameEditFormProps {
   boardInfo: Dashboards;

--- a/components/dashboard/header/ProfileDropdownMenu.tsx
+++ b/components/dashboard/header/ProfileDropdownMenu.tsx
@@ -1,4 +1,4 @@
-import { useDashboardList } from '@/store/memos/useDashboardList';
+import { useDashboardList } from '@/store/memos';
 import useUserInfo from '@/store/memos/useUserInfo';
 import { useRouter } from 'next/router';
 import { DropdownMenu } from '@/components';

--- a/components/dashboard/sidebar/DashboardSidebar.tsx
+++ b/components/dashboard/sidebar/DashboardSidebar.tsx
@@ -5,6 +5,7 @@ import logoSmall from '@/public/icons/logo_small-icon.svg';
 import crownIcon from '@/public/icons/crown-icon.svg';
 import CreateDashboardButton from './CreateDashboardButton';
 import Link from 'next/link';
+import useToggle from '@/hooks/useToggle';
 
 interface DashboardListItemsProps {
   dashboard: Dashboards;
@@ -33,12 +34,12 @@ function DashboardListItem({ dashboard, currentId }: DashboardListItemsProps) {
   return (
     <Link href={`/dashboard/${dashboard.id}`}>
       <div
-        className={`flex items-center mobile:justify-center w-full rounded-md h-45pxr px-12pxr ${
+        className={`flex items-center mobile:justify-center mobile:group-hover:justify-start w-full rounded-md h-45pxr px-12pxr ${
           String(dashboard.id) === currentId && 'bg-violet8'
         } overflow-hidden hover:bg-violet8`}
       >
         <div className={`w-8pxr h-8pxr rounded-full flex-shrink-0 ${bg}`} />
-        <div className="flex items-center mobile:hidden ml-16pxr ">
+        <div className="flex items-center mobile:hidden ml-16pxr mobile:group-hover:flex">
           <p className="overflow-hidden font-medium text-14pxr desktop:text-16pxr mr-6pxr whitespace-nowrap">
             {dashboard.title}
           </p>
@@ -62,24 +63,24 @@ export default function DashboardSidebar({
   currentId,
 }: DashboardSidebarProps) {
   return (
-    <aside className="h-full overflow-x-hidden overflow-y-scroll duration-100 ease-in-out border-r w-160pxr transition-width py-20pxr px-12pxr mobile:w-67pxr desktop:w-300pxr border-r-gray30">
+    <aside className="h-full overflow-x-hidden overflow-y-scroll duration-100 ease-in-out bg-white border-r group transition-width py-20pxr px-12pxr mobile:hover:w-160pxr mobile:w-67pxr w-160pxr desktop:w-300pxr border-r-gray30">
       <Link href="/mydashboard">
         <div className="ml-12px mobile:flex-center">
           <Image
             src={logoLarge}
             alt="내 대시보드로 이동하는 로고"
-            className="mobile:hidden"
+            className="mobile:hidden mobile:group-hover:block"
           />
           <Image
             src={logoSmall}
             alt="내 대시보드로 이동하는 로고"
-            className="hidden mobile:block"
+            className="hidden mobile:block mobile:group-hover:hidden"
           />
         </div>
       </Link>
       <div className="mt-42pxr">
-        <div className="flex items-center justify-between px-12pxr mb-15pxr">
-          <p className="font-bold text-gray50 text-12pxr mobile:hidden">
+        <div className="flex items-center justify-between px-12pxr mb-15pxr mobile:justify-center mobile:group-hover:justify-between">
+          <p className="font-bold text-gray50 text-12pxr mobile:hidden mobile:group-hover:block">
             DashBoards
           </p>
           <CreateDashboardButton />

--- a/components/dashboard/sidebar/DashboardSidebar.tsx
+++ b/components/dashboard/sidebar/DashboardSidebar.tsx
@@ -63,7 +63,7 @@ export default function DashboardSidebar({
   currentId,
 }: DashboardSidebarProps) {
   return (
-    <aside className="h-full overflow-x-hidden overflow-y-scroll duration-100 ease-in-out bg-white border-r group transition-width py-20pxr px-12pxr mobile:hover:w-160pxr mobile:w-67pxr w-160pxr desktop:w-300pxr border-r-gray30">
+    <aside className="h-full overflow-hidden duration-100 ease-in-out bg-white border-r basis-0pxr group transition-width py-20pxr px-12pxr mobile:hover:w-160pxr mobile:w-67pxr w-160pxr desktop:w-300pxr border-r-gray30">
       <Link href="/mydashboard">
         <div className="ml-12px mobile:flex-center">
           <Image
@@ -78,14 +78,14 @@ export default function DashboardSidebar({
           />
         </div>
       </Link>
-      <div className="mt-42pxr">
+      <div className="flex flex-col h-full pt-42pxr pb-30pxr">
         <div className="flex items-center justify-between px-12pxr mb-15pxr mobile:justify-center mobile:group-hover:justify-between">
           <p className="font-bold text-gray50 text-12pxr mobile:hidden mobile:group-hover:block">
             DashBoards
           </p>
           <CreateDashboardButton />
         </div>
-        <div className="flex flex-col w-full gap-3pxr">
+        <div className="flex flex-col w-full overflow-y-scroll gap-3pxr pb-5pxr">
           {dashboardList?.map((dashboard) => {
             return (
               <DashboardListItem

--- a/components/modal/create-dashboard/CreateDashboardModal.tsx
+++ b/components/modal/create-dashboard/CreateDashboardModal.tsx
@@ -2,7 +2,7 @@ import { Modal } from '@/components';
 import { useEffect, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import usePostDashboards from '../data/usePostDashboards';
-import { useDashboardList } from '@/store/memos/useDashboardList';
+import { useDashboardList } from '@/store/memos';
 import { ColorChips, ModalButton } from '@/components';
 export interface ModalProps {
   isOpen: boolean;

--- a/components/myBoard/DashBoards.tsx
+++ b/components/myBoard/DashBoards.tsx
@@ -5,7 +5,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { CreateDashboardModal } from '@/components';
 import useToggle from '@/hooks/useToggle';
-import { useDashboardList } from '@/store/memos/useDashboardList';
+import { useDashboardList } from '@/store/memos';
 import { useEffect, useState } from 'react';
 import { Dashboards } from '@/types/dashboards';
 import PaginationButton from '../common/PaginationButton';
@@ -35,7 +35,7 @@ function Board({
   const bg = colors[color];
   return (
     <Link href={`dashboard/${id}`}>
-      <div className="flex-center justify-between w-full h-70pxr bg-white rounded-lg border border-solid border-gray30 gap-12pxr px-20pxr">
+      <div className="justify-between w-full bg-white border border-solid rounded-lg flex-center h-70pxr border-gray30 gap-12pxr px-20pxr">
         <div className="flex-center gap-16pxr">
           <div className={`w-8pxr h-8pxr rounded-full ${bg}`}></div>
           <div className="flex-center gap-8pxr">
@@ -57,7 +57,7 @@ function CreateBoard() {
     <>
       <button
         onClick={toggle}
-        className="flex-center bg-white h-70pxr rounded-lg border border-solid border-gray30 gap-12pxr"
+        className="bg-white border border-solid rounded-lg flex-center h-70pxr border-gray30 gap-12pxr"
       >
         <div className="font-semibold text-gray70">새로운 대시보드</div>
         <div className="bg-violet8">
@@ -99,8 +99,8 @@ export default function BoardList() {
           ))}
       </div>
       {data && (
-        <div className="flex justify-end items-center gap-16pxr">
-          <div className="text-14pxr text-black">
+        <div className="flex items-center justify-end gap-16pxr">
+          <div className="text-black text-14pxr">
             {totalPage} 페이지 중 {page}
           </div>
           <PaginationButton

--- a/pages/dashboard/[id].tsx
+++ b/pages/dashboard/[id].tsx
@@ -1,9 +1,9 @@
 import { useRouter } from 'next/router';
-import { useDashboardList } from '@/store/memos/useDashboardList';
+import { useDashboardList } from '@/store/memos';
 import { Dashboards } from '@/types/dashboards';
 import DashboardLayout from '@/page-layout/DashboardLayout';
 import { DashboardHeader, DashboardSidebar } from '@/components';
-import Columns from '@/components/dashboard/column';
+import ColumnList from '@/components/dashboard/column';
 
 export default function DashboardPage() {
   const { dashboardList } = useDashboardList();
@@ -23,7 +23,7 @@ export default function DashboardPage() {
     <div>
       <DashboardLayout
         header={<DashboardHeader dashboard={dashboard} />}
-        main={<Columns />}
+        main={<ColumnList />}
         sidebar={
           <DashboardSidebar
             dashboardList={dashboardList}

--- a/pages/dashboard/[id]/edit/index.tsx
+++ b/pages/dashboard/[id]/edit/index.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { useRouter } from 'next/router';
 import BoardEditMain from '@/components/boardEdit/BoardEditMain';
 import DashboardLayout from '@/page-layout/DashboardLayout';
-import { useDashboardList } from '@/store/memos/useDashboardList';
+import { useDashboardList } from '@/store/memos';
 import { Dashboards } from '@/types/dashboards';
 
 function BoardEditPage() {

--- a/pages/mydashboard/index.tsx
+++ b/pages/mydashboard/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useDashboardList } from '@/store/memos/useDashboardList';
+import { useDashboardList } from '@/store/memos';
 import DashboardLayout from '@/page-layout/DashboardLayout';
 import { Header, DashboardSidebar } from '@/components';
 import useGetDashboards from '@/components/dashboard/data/useGetDashboards';

--- a/store/memos/index.ts
+++ b/store/memos/index.ts
@@ -1,2 +1,2 @@
-
-export {default as useUserInfo } from './useUserInfo'
+export { default as useUserInfo } from './useUserInfo';
+export { default as useDashboardList } from './useDashboardList';

--- a/store/memos/useDashboardList.ts
+++ b/store/memos/useDashboardList.ts
@@ -21,11 +21,11 @@ const deleteBoard = (prevList: Dashboards[], boardId: number) => {
   return { dashboardList: newList };
 };
 
-export const useDashboardList = create(
+const useDashboardList = create(
   persist<DashboardListStoreType>(
     (set) => ({
       dashboardList: [],
-      setDashboardList: (newList) => {
+      setDashboardList: (newList: Dashboards[]) => {
         set({
           dashboardList: newList,
         });
@@ -40,3 +40,5 @@ export const useDashboardList = create(
     { name: 'dashboardList' }
   )
 );
+
+export default useDashboardList;


### PR DESCRIPTION
## 🛠️주요 변경 사항
- 사이드바의 로고, 타이틀 부분은 고정되고 리스트 부분만 스크롤 되도록 수정
- 모바일에서 사이드바 클릭시 태블릿 사이드바 형태로 변경되어 대시보드 이름을 확인할 수 있도록 했습니다.

## 📣리뷰어에게 하고싶은 말
- 모바일에서는 hover 조건이 클릭, 클릭은 더블클릭 하면 되더라구요! 그래서 hover에 따라 형태가 달라지도록 구현 했습니다.
    - 대신 모바일에서는 사이드바 클릭 -> 사이드바 오픈 -> 거기서 다시 클릭 해야지 대시보드 생성 모달이 나오거나, ~~원하는 대시보드로 이동이 가능~~합니다.🥲

## 🖼️스크린샷(선택)

https://github.com/codeit-sprint-team1/Taskify/assets/144652458/04b41405-c24e-49e2-9a76-3716791d91bb



## ❗관련이슈
- close #66 
