### PR TITLE
refactor: 상태 드롭다운 API 연결

### DIFF
--- a/components/modal/DropdownState.tsx
+++ b/components/modal/DropdownState.tsx
@@ -1,97 +1,80 @@
-import { MouseEvent, useEffect, useRef, useState } from 'react';
+import { MouseEvent, forwardRef, useEffect, useRef, useState } from 'react';
 import dropdownImage from '@/public/icons/dropdown-icon.svg';
 import Image from 'next/image';
 import { Label } from '..';
 import ColumnState from '../common/ColumnState';
+import { Columns } from '@/types/columns';
+import useOnClickOutside from '@/hooks/useOnClickOutside';
 
-interface DropdownManagerProps {
+interface DropdownStateProps {
   initialState: string;
-  states: string[];
+  onChange: (value: number) => void;
+  states: Columns[];
 }
 
-export default function DropdownState({
-  initialState,
-  states,
-}: DropdownManagerProps) {
-  const [value, setValue] = useState(initialState);
-  const [isOpen, setIsOpen] = useState(false);
-  const [selectedState, setSelectedState] = useState('');
-  const dropdownRef = useRef<HTMLUListElement>(null);
-  const InputRef = useRef<HTMLInputElement>(null);
+const DropdownState = forwardRef<HTMLInputElement, DropdownStateProps>(
+  ({ initialState, onChange, states }: DropdownStateProps, ref) => {
+    const [value, setValue] = useState(initialState); //input에 보이는 값
+    const {
+      isOn: isOpen,
+      close,
+      ref: dropdownRef,
+      toggle,
+    } = useOnClickOutside();
 
-  const handleStateClick = (state: string) => {
-    setValue(state);
-    setSelectedState(state);
-    setIsOpen(false);
-  };
-  useEffect(() => {
-    const handleClickOutside = (event: Event) => {
-      if (InputRef.current && InputRef.current.contains(event.target as Node))
-        return;
-
-      if (
-        dropdownRef.current &&
-        !dropdownRef.current.contains(event.target as Node)
-      ) {
-        setIsOpen(false);
-      }
+    const handleStateClick = (state: Columns) => {
+      setValue(state.title);
+      onChange(state.id);
+      close();
     };
 
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
-  }, [dropdownRef]);
-
-  return (
-    <div>
-      <Label htmlFor="members" text="상태" />
-      <div className="relative flex items-center ">
-        <input
-          type="button"
-          onClick={() => setIsOpen(!isOpen)}
-          ref={InputRef}
-          className={`block w-full rounded-md border border-solid border-gray30
+    return (
+      <>
+        <Label htmlFor="members" text="상태" />
+        <div ref={dropdownRef}>
+          <div onClick={toggle} className="relative flex items-center ">
+            <input
+              ref={ref}
+              type="button"
+              className={`block w-full rounded-md border border-solid border-gray30
            pr-16pxr ${
-             selectedState && value ? 'pl-40pxr' : 'pl-11pxr'
+             value ? 'pl-40pxr' : 'pl-11pxr'
            }  tablet:text-16pxr mobile:text-14pxr text-gray70 placeholder:text-gray40 outline-0 h-50pxr cursor-pointer`}
-        />
-        <div
-          className="absolute pl-10pxr cursor-pointer"
-          onClick={() => setIsOpen(!isOpen)}
-        >
-          {selectedState && value ? (
-            <ColumnState state={selectedState} />
-          ) : (
-            <ColumnState state={value} />
+            />
+            <div className="absolute cursor-pointer pl-10pxr">
+              {value && <ColumnState state={value} />}
+            </div>
+
+            <button tabIndex={-1}>
+              <Image
+                src={dropdownImage}
+                alt="목록보기 화살표 이미지"
+                className="absolute right-10pxr top-10pxr"
+                width={26}
+                height={26}
+              />
+            </button>
+          </div>
+          {isOpen && (
+            <ul className="overflow-y-auto max-h-160pxr">
+              {states?.map((state) => (
+                <li key={state.id}>
+                  <button
+                    className="block w-full hover:border hover:border-gray40 hover:rounded-md tablet:text-16pxr mobile:text-14pxr text-gray70 placeholder:text-gray40 "
+                    onClick={() => handleStateClick(state)}
+                  >
+                    <div className="flex items-center gap-6pxr pl-10pxr p-5pxr ">
+                      <ColumnState state={state.title} />
+                    </div>
+                  </button>
+                </li>
+              ))}
+            </ul>
           )}
         </div>
+      </>
+    );
+  }
+);
 
-        <button onClick={() => setIsOpen(!isOpen)} tabIndex={-1}>
-          <Image
-            src={dropdownImage}
-            alt="목록보기 화살표 이미지"
-            className="absolute right-10pxr top-10pxr"
-            width={26}
-            height={26}
-          />
-        </button>
-      </div>
-      <ul ref={dropdownRef} className="max-h-160pxr overflow-y-auto">
-        {isOpen &&
-          states?.map((state) => (
-            <li key={state}>
-              <button
-                className="block w-full hover:border hover:border-gray40 hover:rounded-md tablet:text-16pxr mobile:text-14pxr text-gray70 placeholder:text-gray40  "
-                onClick={() => handleStateClick(state)}
-              >
-                <div className="flex items-center gap-6pxr pl-10pxr p-5pxr ">
-                  <ColumnState state={state} />
-                </div>
-              </button>
-            </li>
-          ))}
-      </ul>
-    </div>
-  );
-}
+export default DropdownState;

--- a/hooks/useOnClickOutside.ts
+++ b/hooks/useOnClickOutside.ts
@@ -19,6 +19,7 @@ const useOnClickOutside = () => {
         ref.current !== null &&
         !ref.current.contains(e.target as Node)
       ) {
+        console.log('닫힙니다');
         setIsOn(false);
       }
     };
@@ -29,7 +30,7 @@ const useOnClickOutside = () => {
       document.removeEventListener('mousedown', handleClickOutside);
       document.removeEventListener('touchstart', handleClickOutside);
     };
-  }, [ref]);
+  }, [ref, isOn]);
 
   return { isOn, ref, toggle, close };
 };

--- a/hooks/useOnClickOutside.ts
+++ b/hooks/useOnClickOutside.ts
@@ -8,9 +8,17 @@ const useOnClickOutside = () => {
     setIsOn(!isOn);
   };
 
+  const close = () => {
+    setIsOn(false);
+  };
+
   useEffect(() => {
     const handleClickOutside = (e: Event) => {
-      if (ref.current !== null && !ref.current.contains(e.target as Node)) {
+      if (
+        isOn &&
+        ref.current !== null &&
+        !ref.current.contains(e.target as Node)
+      ) {
         setIsOn(false);
       }
     };
@@ -21,10 +29,9 @@ const useOnClickOutside = () => {
       document.removeEventListener('mousedown', handleClickOutside);
       document.removeEventListener('touchstart', handleClickOutside);
     };
-  }),
-    [ref];
+  }, [ref]);
 
-  return { isOn, ref, toggle };
+  return { isOn, ref, toggle, close };
 };
 
 export default useOnClickOutside;


### PR DESCRIPTION
## 🛠️주요 변경 사항
- 상태 드롭다운이 속성값을 받아 적용하도록 했습니다. (자세한 설명은 코멘트 남기겠습니다.)
- 기존 토글 기능을 useOnClickOutside 훅으로 교체했습니다.
- 상태 드롭다운 forwardRef로 감쌌습니다.

## 📣리뷰어에게 하고싶은 말
- 토글 기능은 제가 만들어둔 것이 있었는데, 훅 사용하면 코드가 짧아질 것 같아서 교체했습니다. 혹시 문제가 발생하면 원상복귀해둘게요!!
- 아래는 상태드롭다운 사용 예시(?) 입니다.
```ts
import useGetColum from '@/components/dashboard/data/useGetColums';
import DropdownState from '@/components/modal/DropdownState';
import { useEffect, useState } from 'react';

export default function TestPage() {
  const columnId = 3699; //컬럼컴포넌트 → 버튼 → 모달
  const dashboardId = 1116; //페이지 → 컬럼컴포넌트 → 버튼 → 모달

//선택된 columnId를 받아 활용합니다 (아마 setValue)
  const onChange = (value: number) => {
    //API로 보낼 값 set해주기
  };

//대시보드의 모든 컬럼 정보를 가져와야합니다.
  const { execute, columns } = useGetColum(dashboardId); 
//가져운 컬럼 중 현재 카드가 속한 컬럼의 정보만 따로 빼둡니다.
  const currentColumns = columns?.find((column) => {
    return column.id === columnId;
  });

//대시보드의 모든 컬럼 정보를 가져오는 함수를 실행하는 부분입니다.
  useEffect(() => {
    execute();
  }, []);

//만약 currentColumns가 없다면 return 합니다. (서버사이드렌더링으로 인한 문제 방지)
 if (!currentColumns) return;

  return (
    <DropdownState
      initialState={currentColumns?.title ?? ''} //현재상태값 (현재 속한 컬럼의 title)
      states={columns} //모든 컬럼 정보 배열
      onChange={onChange}
    />
  );
}

```

## 🖼️스크린샷(선택)
https://github.com/codeit-sprint-team1/Taskify/assets/144652458/afa4e259-9d21-4e68-8eb7-5cb9f6827402
- 콘솔에 찍히는 값이 상태의 id(column id)이며, onChange 발생시 전달되는 값입니다.


## ❗관련이슈
- #21 
