### PR TITLE
fix: 헤더 프로필 드롭다운 위치 수정, 멤버 목록 스크롤, 대시보드 설정 접근 제한, 초대하기 성공 안내 추가

### DIFF
--- a/components/common/DropdownMenu.tsx
+++ b/components/common/DropdownMenu.tsx
@@ -23,7 +23,7 @@ interface DropdownMenu {
 
 export default function DropdownMenu({ options }: DropdownMenu) {
   return (
-    <ul className="absolute right-0pxr mt-10pxr w-115pxr border border-2pxr border-gray30 rounded-lg p-8pxr bg-white">
+    <ul className="absolute top-28pxr right-0pxr mt-10pxr w-115pxr border border-2pxr border-gray30 rounded-lg p-8pxr bg-white">
       {options.map((option) => {
         return (
           <li key={option.key}>

--- a/components/dashboard/header/DashboardHeader.tsx
+++ b/components/dashboard/header/DashboardHeader.tsx
@@ -14,14 +14,16 @@ export default function DashboardHeader({ dashboard }: DashboardHeaderProps) {
     <Header dashboard={dashboard}>
       <div className="flex items-center desktop:gap-32pxr gap-24pxr mobile:gap-12pxr">
         <div className="flex">
-          <HeaderButton
-            onClick={handleSettingButtonClick}
-            src={settingIcon}
-            alt="관리 페이지로 이동하는 톱니 모양"
-          >
-            설정
-          </HeaderButton>
-          <InviteButton />
+          {dashboard.createdByMe && (
+            <HeaderButton
+              onClick={handleSettingButtonClick}
+              src={settingIcon}
+              alt="관리 페이지로 이동하는 톱니 모양"
+            >
+              설정
+            </HeaderButton>
+          )}
+          {dashboard.createdByMe && <InviteButton />}
         </div>
         <HeaderMembers dashboardId={dashboard.id} />
         <div className="w-1pxr h-38pxr desktop:mr-32pxr mr-24pxr mobile:mr-12pxr bg-gray30" />

--- a/components/dashboard/header/Header.tsx
+++ b/components/dashboard/header/Header.tsx
@@ -29,6 +29,7 @@ export default function Header({ dashboard, children }: HeaderProps) {
   const { isOn, ref, toggle } = useOnClickOutside();
 
   useEffect(() => {
+    if (userInfo === null) return;
     setNickname(userInfo.nickname);
     setProfileImage(userInfo.profileImageUrl);
   }, []);

--- a/components/dashboard/header/HeaderMembers.tsx
+++ b/components/dashboard/header/HeaderMembers.tsx
@@ -3,110 +3,6 @@ import useGetMembers from '@/components/boardEdit/data/useGetMembers';
 import { useEffect, useState } from 'react';
 import { Members } from '@/types/members';
 import MemberInfoItem from './MemberInfoItem';
-
-const mock = [
-  {
-    id: 1,
-    email: 'user1@example.com',
-    nickname: 'User1',
-    profileImageUrl: '',
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    isOwner: true,
-    userId: 101,
-  },
-  {
-    id: 2,
-    email: 'user2@example.com',
-    nickname: 'User2',
-    profileImageUrl: '',
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    isOwner: false,
-    userId: 102,
-  },
-  {
-    id: 3,
-    email: 'user3@example.com',
-    nickname: 'User3',
-    profileImageUrl: '',
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    isOwner: false,
-    userId: 103,
-  },
-  {
-    id: 4,
-    email: 'user4@example.com',
-    nickname: 'User4',
-    profileImageUrl: '',
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    isOwner: true,
-    userId: 104,
-  },
-  {
-    id: 5,
-    email: 'user5@example.com',
-    nickname: 'User5',
-    profileImageUrl: '',
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    isOwner: false,
-    userId: 105,
-  },
-  {
-    id: 6,
-    email: 'user6@example.com',
-    nickname: 'User6',
-    profileImageUrl: '',
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    isOwner: true,
-    userId: 106,
-  },
-  {
-    id: 7,
-    email: 'user7@example.com',
-    nickname: 'User7',
-    profileImageUrl: '',
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    isOwner: false,
-    userId: 107,
-  },
-  {
-    id: 8,
-    email: 'user8@example.com',
-    nickname: 'User8',
-    profileImageUrl: '',
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    isOwner: true,
-    userId: 108,
-  },
-  {
-    id: 9,
-    email: 'user9@example.com',
-    nickname: 'User9',
-    profileImageUrl: '',
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    isOwner: false,
-    userId: 109,
-  },
-  {
-    id: 10,
-    email: 'user10@example.com',
-    nickname: 'User10',
-    profileImageUrl: '',
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    isOwner: true,
-    userId: 110,
-  },
-];
-
 interface HeaderMembersProps {
   dashboardId: number;
 }
@@ -201,7 +97,7 @@ export default function HeaderMembers({ dashboardId }: HeaderMembersProps) {
           </div>
         )}
         <div className="absolute flex flex-col gap-5pxr -left-15pxr max-h-200pxr overflow-scroll invisible group-hover:visible p-5pxr bg-violet8 rounded-md mt-1pxr">
-          {mock?.map((member) => {
+          {restMembers?.map((member) => {
             return (
               <MemberInfoItem
                 showImage

--- a/components/dashboard/header/HeaderMembers.tsx
+++ b/components/dashboard/header/HeaderMembers.tsx
@@ -3,8 +3,109 @@ import useGetMembers from '@/components/boardEdit/data/useGetMembers';
 import { useEffect, useState } from 'react';
 import { Members } from '@/types/members';
 import MemberInfoItem from './MemberInfoItem';
-import Link from 'next/link';
-import { useRouter } from 'next/router';
+
+const mock = [
+  {
+    id: 1,
+    email: 'user1@example.com',
+    nickname: 'User1',
+    profileImageUrl: '',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    isOwner: true,
+    userId: 101,
+  },
+  {
+    id: 2,
+    email: 'user2@example.com',
+    nickname: 'User2',
+    profileImageUrl: '',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    isOwner: false,
+    userId: 102,
+  },
+  {
+    id: 3,
+    email: 'user3@example.com',
+    nickname: 'User3',
+    profileImageUrl: '',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    isOwner: false,
+    userId: 103,
+  },
+  {
+    id: 4,
+    email: 'user4@example.com',
+    nickname: 'User4',
+    profileImageUrl: '',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    isOwner: true,
+    userId: 104,
+  },
+  {
+    id: 5,
+    email: 'user5@example.com',
+    nickname: 'User5',
+    profileImageUrl: '',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    isOwner: false,
+    userId: 105,
+  },
+  {
+    id: 6,
+    email: 'user6@example.com',
+    nickname: 'User6',
+    profileImageUrl: '',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    isOwner: true,
+    userId: 106,
+  },
+  {
+    id: 7,
+    email: 'user7@example.com',
+    nickname: 'User7',
+    profileImageUrl: '',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    isOwner: false,
+    userId: 107,
+  },
+  {
+    id: 8,
+    email: 'user8@example.com',
+    nickname: 'User8',
+    profileImageUrl: '',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    isOwner: true,
+    userId: 108,
+  },
+  {
+    id: 9,
+    email: 'user9@example.com',
+    nickname: 'User9',
+    profileImageUrl: '',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    isOwner: false,
+    userId: 109,
+  },
+  {
+    id: 10,
+    email: 'user10@example.com',
+    nickname: 'User10',
+    profileImageUrl: '',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    isOwner: true,
+    userId: 110,
+  },
+];
 
 interface HeaderMembersProps {
   dashboardId: number;
@@ -45,7 +146,7 @@ export default function HeaderMembers({ dashboardId }: HeaderMembersProps) {
   } = useGetMembers({
     boardid: dashboardId,
     page: 1,
-    size: 20,
+    size: 1000,
   });
 
   useEffect(() => {
@@ -99,9 +200,8 @@ export default function HeaderMembers({ dashboardId }: HeaderMembersProps) {
             <ProfileImage textDiv name={`${restMembers?.length}+`} src="" />
           </div>
         )}
-
-        <div className="absolute right-0pxr invisible group-hover:visible p-5pxr bg-violet8 rounded-md mt-1pxr">
-          {restMembers?.map((member) => {
+        <div className="absolute flex flex-col gap-5pxr -left-15pxr max-h-200pxr overflow-scroll invisible group-hover:visible p-5pxr bg-violet8 rounded-md mt-1pxr">
+          {mock?.map((member) => {
             return (
               <MemberInfoItem
                 showImage
@@ -112,14 +212,6 @@ export default function HeaderMembers({ dashboardId }: HeaderMembersProps) {
               />
             );
           })}
-          {totalCount > 20 && (
-            <Link
-              href={`/dashboard/${dashboardId}/edit`}
-              className="block text-11pxr w-full py-5pxr text-gray50 text-center"
-            >
-              전체 멤버 보기
-            </Link>
-          )}
         </div>
       </div>
     </div>

--- a/components/dashboard/header/ProfileDropdownMenu.tsx
+++ b/components/dashboard/header/ProfileDropdownMenu.tsx
@@ -39,7 +39,7 @@ export default function ProfileDropdownMenu() {
   }
 
   return (
-    <div className="absolute -right-15pxr top-15pxr">
+    <div className="absolute -right-25pxr top-5pxr">
       <DropdownMenu options={options} />
     </div>
   );

--- a/components/dashboard/header/ProfileDropdownMenu.tsx
+++ b/components/dashboard/header/ProfileDropdownMenu.tsx
@@ -38,5 +38,9 @@ export default function ProfileDropdownMenu() {
     options = options.splice(1);
   }
 
-  return <DropdownMenu options={options} />;
+  return (
+    <div className="absolute -right-15pxr top-15pxr">
+      <DropdownMenu options={options} />
+    </div>
+  );
 }

--- a/components/modal/Invite/InviteModal.tsx
+++ b/components/modal/Invite/InviteModal.tsx
@@ -59,8 +59,10 @@ export default function InviteModal({
         message: error.response.data.message,
       });
     } else {
-      notify({ type: 'success', text: '초대를 완료했습니다 💌' });
       handleCancel();
+    }
+    if (response) {
+      notify({ type: 'success', text: '초대를 완료했습니다 💌' });
     }
   }, [error, loading]);
 

--- a/components/modal/Invite/InviteModal.tsx
+++ b/components/modal/Invite/InviteModal.tsx
@@ -6,6 +6,7 @@ import usePostInvitations from '../data/usePostInvitations';
 import { useEffect } from 'react';
 import { useRouter } from 'next/router';
 import { Invitations } from '@/types/invitations';
+import { notify } from '@/components/common/Toast';
 
 export interface InviteModalForm {
   email: string;
@@ -58,6 +59,7 @@ export default function InviteModal({
         message: error.response.data.message,
       });
     } else {
+      notify({ type: 'success', text: '초대를 완료했습니다 💌' });
       handleCancel();
     }
   }, [error, loading]);

--- a/hooks/useOnClickOutside.ts
+++ b/hooks/useOnClickOutside.ts
@@ -19,7 +19,6 @@ const useOnClickOutside = () => {
         ref.current !== null &&
         !ref.current.contains(e.target as Node)
       ) {
-        console.log('닫힙니다');
         setIsOn(false);
       }
     };


### PR DESCRIPTION
## 🛠️주요 변경 사항
- 드롭다운 위치 조정
- 멤버 목록 1000명 불러오고 스크롤
- 대시보드 오너한테만 헤더에 왕관, 설정버튼, 초대하기 버튼이 노출됩니다.
- 초대하기 성공시 notify 뜹니다.

## 📣리뷰어에게 하고싶은 말
- 프로필 높이 맞추면서 flex 줬더니 드롭다운의 위치가 바뀌었네요. 미리 꼼꼼하게 확인했어야 했는데ㅠㅠ
- 이제 발견해서 수정했습니다!

## 🖼️스크린샷(선택)
[드롭다운 위치 조정]
<img width="210" alt="드롭다운위치" src="https://github.com/codeit-sprint-team1/Taskify/assets/144652458/d4c34b09-7c4d-42a1-9374-caac17ad931b">

[멤버 목록 스크롤]
<img width="210" alt="Screen Shot 2024-01-04 at 14 56 14" src="https://github.com/codeit-sprint-team1/Taskify/assets/144652458/cfe1677c-0f89-4790-89ed-f495b8ceeb1e">

[대시보드 Owner에게만 설정/초대하기 버튼 노출]
<img width="692" alt="Screen Shot 2024-01-04 at 14 57 30" src="https://github.com/codeit-sprint-team1/Taskify/assets/144652458/7f9de2ce-761b-4ef4-b3f9-74030bcabddd">

[초대하기 성공시 notify]
<img width="262" alt="Screen Shot 2024-01-04 at 14 59 49" src="https://github.com/codeit-sprint-team1/Taskify/assets/144652458/8fc0803d-19aa-46a7-aeb5-b0f58f44b406">

## ❗관련이슈
