### PR TITLE
feat: 할일수정 모달 제작

### DIFF
--- a/components/modal/DropdownManager.tsx
+++ b/components/modal/DropdownManager.tsx
@@ -115,7 +115,7 @@ const DropdownManager = forwardRef<HTMLInputElement, DropdownManagerProps>(
                 selectedMember === internalValue && internalValue
                   ? 'pl-40pxr'
                   : 'pl-11pxr'
-              }  tablet:text-16pxr mobile:text-14pxr text-gray70 placeholder:text-gray40 focus:border-violet outline-0 h-50pxr `}
+              }  tablet:text-16pxr mobile:text-14pxr text-gray70 placeholder:text-gray40 focus:border-violet outline-0 h-50pxr`}
           />
           {selectedMember === internalValue && internalValue && (
             <div className="absolute pl-10pxr">

--- a/components/modal/Modal.tsx
+++ b/components/modal/Modal.tsx
@@ -13,15 +13,16 @@ interface ModalMainProps {
   children?: ReactNode;
   onSubmit: (() => void) | ((e: FormEvent) => void);
   isOpen: boolean;
+  classNames?: string;
 }
 
-function ModalMain({ children, isOpen, onSubmit }: ModalMainProps) {
+function ModalMain({ children, isOpen, onSubmit, classNames }: ModalMainProps) {
   return (
     <Portal selector="portal" show={isOpen}>
       <div className="fixed top-[0px] left-[0px] flex-center bg-black/50 w-screen h-screen">
         <form
           onSubmit={onSubmit}
-          className="fixed flex flex-col bg-white rounded-md gap-28pxr max-w-[730px] py-28pxr px-28pxr mobile:w-327pxr mobile:px-20pxr"
+          className={`fixed flex flex-col bg-white rounded-md gap-28pxr max-w-[730px] py-28pxr px-28pxr mobile:w-327pxr mobile:px-20pxr ${classNames}`}
         >
           {children}
         </form>

--- a/components/modal/create-card/CreateCardModal.tsx
+++ b/components/modal/create-card/CreateCardModal.tsx
@@ -32,7 +32,6 @@ export default function CreateCardModal({
   dashboardId,
   columnId,
 }: ModalProps) {
-  const [formData, setFormData] = useState<FormData>();
   const defaultValues = {
     title: '',
     manager: '',
@@ -40,9 +39,6 @@ export default function CreateCardModal({
     dueDate: '',
     imageUrl: '',
     tags: [],
-    assigneeUserId: 0,
-    dashboardId: 0,
-    columnId: 0,
   };
   const {
     control,
@@ -106,10 +102,14 @@ export default function CreateCardModal({
   };
 
   return (
-    <Modal isOpen={isOpen} onSubmit={handleSubmit(onSubmit)}>
+    <Modal
+      isOpen={isOpen}
+      onSubmit={handleSubmit(onSubmit)}
+      classNames="w-506pxr"
+    >
       <div className="max-h-[90vh] overflow-y-auto flex flex-col gap-20pxr">
         <Modal.Title>할 일 생성</Modal.Title>
-        <div className="flex flex-col gap-32pxr w-506pxr">
+        <div className="flex flex-col gap-32pxr ">
           <div className="w-217pxr mobile:w-287pxr">
             <Controller
               control={control}

--- a/components/modal/edit-card/EditCardModal.tsx
+++ b/components/modal/edit-card/EditCardModal.tsx
@@ -102,35 +102,43 @@ export default function EditCardModal({
   };
 
   return (
-    <Modal isOpen={isOpen} onSubmit={handleSubmit(onSubmit)}>
+    <Modal
+      isOpen={isOpen}
+      onSubmit={handleSubmit(onSubmit)}
+      classNames="w-506pxr"
+    >
       <div className="max-h-[90vh] overflow-y-auto flex flex-col gap-20pxr">
         <Modal.Title>할 일 수정</Modal.Title>
-        <div className="flex flex-col gap-32pxr w-506pxr">
-          <div className="w-217pxr mobile:w-287pxr">
-            <Controller
-              control={control}
-              name="manager"
-              render={({ field: { ref, ...rest } }) => (
-                <DropdownManager
-                  ref={ref}
-                  {...rest}
-                  dashboardId={card.dashboardId}
-                />
-              )}
-            />
-            <Controller
-              control={control}
-              name="states"
-              render={({ field: { ref, ...rest } }) => (
-                <DropdownState
-                  ref={ref}
-                  {...rest}
-                  initialState={state.title}
-                  states={states}
-                  onChange={handleStateChange}
-                />
-              )}
-            />
+        <div className="flex flex-col gap-32pxr ">
+          <div className="flex flex-row justify-between mobile:flex-col mobile:gap-24pxr">
+            <div className="w-217pxr mobile:w-287pxr">
+              <Controller
+                control={control}
+                name="states"
+                render={({ field: { ref, ...rest } }) => (
+                  <DropdownState
+                    ref={ref}
+                    {...rest}
+                    initialState={state.title}
+                    states={states}
+                    onChange={handleStateChange}
+                  />
+                )}
+              />
+            </div>
+            <div className="w-217pxr mobile:w-287pxr">
+              <Controller
+                control={control}
+                name="manager"
+                render={({ field: { ref, ...rest } }) => (
+                  <DropdownManager
+                    ref={ref}
+                    {...rest}
+                    dashboardId={card.dashboardId}
+                  />
+                )}
+              />
+            </div>
           </div>
 
           <Controller

--- a/components/modal/edit-card/EditCardModal.tsx
+++ b/components/modal/edit-card/EditCardModal.tsx
@@ -38,7 +38,7 @@ export default function EditCardModal({
   states,
   state,
 }: ModalProps) {
-  const [selectedStateId, setSelectedStateId] = useState<number | null>(null);
+  const [selectedStateId, setSelectedStateId] = useState<number>(0);
   const defaultValues = {
     title: card?.title,
     manager: card?.assignee.nickname,
@@ -52,9 +52,6 @@ export default function EditCardModal({
     cardId: card?.id,
   };
 
-  {
-    console.log(defaultValues.tags);
-  }
   const {
     control,
     handleSubmit,
@@ -96,6 +93,7 @@ export default function EditCardModal({
     imageUrl: watch('imageUrl'),
     tags: watch('tags'),
     cardId: card.id,
+    columnId: selectedStateId,
   });
 
   const onSubmit = async () => {

--- a/components/modal/edit-card/EditCardModal.tsx
+++ b/components/modal/edit-card/EditCardModal.tsx
@@ -1,0 +1,193 @@
+import { ImagePick, Input, Modal, SelectDate, TextArea } from '@/components';
+import { useEffect, useState } from 'react';
+import { Controller, useForm } from 'react-hook-form';
+import { ModalButton } from '@/components';
+import DropdownManager from '../DropdownManager';
+import AddTag from '../edit-card/AddTag';
+import { DevTool } from '@hookform/devtools';
+import usePutCard from './data/usePutCard';
+import DropdownState from '../DropdownState';
+import { Columns } from '@/types/columns';
+import { Card } from '@/types/cards';
+
+export interface ModalProps {
+  isOpen: boolean;
+  onCancel: () => void;
+  card: Card;
+  state: Columns;
+  states: Columns[];
+}
+
+export interface EditCardModalForm {
+  manager: string;
+  title: string;
+  description: string;
+  dueDate: string | null;
+  imageUrl: string | null;
+  tags: string[];
+  assigneeUserId: number | null;
+  dashboardId: number;
+  columnId: number;
+  states: Columns[];
+}
+
+export default function EditCardModal({
+  isOpen,
+  onCancel,
+  card,
+  states,
+  state,
+}: ModalProps) {
+  const [selectedStateId, setSelectedStateId] = useState<number | null>(null);
+  const defaultValues = {
+    title: card?.title,
+    manager: card?.assignee.nickname,
+    description: card?.description,
+    dueDate: card?.dueDate,
+    imageUrl: card?.imageUrl,
+    tags: card?.tags,
+    assigneeUserId: card?.assignee?.id,
+    dashboardId: card?.dashboardId,
+    columnId: state?.id,
+    cardId: card?.id,
+  };
+
+  {
+    console.log(defaultValues.tags);
+  }
+  const {
+    control,
+    handleSubmit,
+    watch,
+    reset,
+    setValue,
+    formState: { isValid, errors },
+  } = useForm<EditCardModalForm>({
+    defaultValues,
+    mode: 'onChange',
+  });
+
+  const handleImageSelect = (imageUrl: string) => {
+    setValue('imageUrl', imageUrl);
+  };
+
+  const onTagListChange = (newTagList: string[]) => {
+    setValue('tags', newTagList);
+  };
+
+  const handleStateChange = (newStateId: number) => {
+    setSelectedStateId(newStateId);
+  };
+
+  const handleCancel = () => {
+    reset();
+    onCancel();
+  };
+
+  const {
+    execute: putCard,
+    data,
+    loading,
+  } = usePutCard({
+    assigneeUserId: watch('assigneeUserId'),
+    title: watch('title'),
+    description: watch('description'),
+    dueDate: watch('dueDate')?.toString(),
+    imageUrl: watch('imageUrl'),
+    tags: watch('tags'),
+    cardId: card.id,
+  });
+
+  const onSubmit = async () => {
+    await putCard();
+    handleCancel();
+  };
+
+  return (
+    <Modal isOpen={isOpen} onSubmit={handleSubmit(onSubmit)}>
+      <div className="max-h-[90vh] overflow-y-auto flex flex-col gap-20pxr">
+        <Modal.Title>할 일 수정</Modal.Title>
+        <div className="flex flex-col gap-32pxr w-506pxr">
+          <div className="w-217pxr mobile:w-287pxr">
+            <Controller
+              control={control}
+              name="manager"
+              render={({ field: { ref, ...rest } }) => (
+                <DropdownManager
+                  ref={ref}
+                  {...rest}
+                  dashboardId={card.dashboardId}
+                />
+              )}
+            />
+            <Controller
+              control={control}
+              name="states"
+              render={({ field: { ref, ...rest } }) => (
+                <DropdownState
+                  ref={ref}
+                  {...rest}
+                  initialState={state.title}
+                  states={states}
+                  onChange={handleStateChange}
+                />
+              )}
+            />
+          </div>
+
+          <Controller
+            control={control}
+            name="title"
+            rules={{ required: true }}
+            render={({ field: { ref, ...rest } }) => (
+              <Input
+                ref={ref}
+                {...rest}
+                label="제목"
+                required
+                classNames="mobile:w-287pxr"
+              />
+            )}
+          />
+          <Controller
+            control={control}
+            name="description"
+            rules={{ required: true }}
+            render={({ field: { ref, ...rest } }) => (
+              <TextArea ref={ref} {...rest} label="설명" required />
+            )}
+          />
+          <Controller
+            control={control}
+            name="dueDate"
+            render={({ field: { ref, ...rest } }) => (
+              <SelectDate {...rest} label="마감일" />
+            )}
+          />
+          <Controller
+            control={control}
+            name="imageUrl"
+            render={({ field: { ref, ...rest } }) => (
+              <ImagePick
+                ref={ref}
+                {...rest}
+                onSelectImage={handleImageSelect}
+                label="이미지"
+                columnId={state?.id}
+              />
+            )}
+          />
+          <Controller
+            control={control}
+            name="tags"
+            render={() => <AddTag onTagListChange={onTagListChange} />}
+          />
+        </div>
+        <ModalButton disabled={!isValid || loading} onCancel={handleCancel}>
+          수정
+        </ModalButton>
+        <DevTool control={control} />
+      </div>
+    </Modal>
+  );
+}

--- a/components/modal/edit-card/data/usePutCard.tsx
+++ b/components/modal/edit-card/data/usePutCard.tsx
@@ -11,7 +11,8 @@ const usePutCard = ({
   tags,
   imageUrl,
   cardId,
-}: CreateCard & { cardId: number }) => {
+  columnId,
+}: CreateCard & { cardId: number; columnId: number }) => {
   const putCard = useCallback(
     () =>
       axiosAuthInstance.put<CreateCard>(`cards/${cardId}`, {
@@ -21,8 +22,9 @@ const usePutCard = ({
         dueDate,
         tags,
         imageUrl,
+        columnId,
       }),
-    [title, description, dueDate, tags, imageUrl, cardId]
+    [title, description, dueDate, tags, imageUrl, cardId, columnId]
   );
 
   const { execute, loading, error, data } = useAsync(putCard, true);

--- a/components/modal/edit-card/data/usePutCard.tsx
+++ b/components/modal/edit-card/data/usePutCard.tsx
@@ -1,0 +1,38 @@
+import { useCallback } from 'react';
+import { axiosAuthInstance } from '@/utils';
+import { useAsync } from '@/hooks/useAsync';
+import { CreateCard } from '@/types/cards';
+
+const usePutCard = ({
+  assigneeUserId,
+  title,
+  description,
+  dueDate,
+  tags,
+  imageUrl,
+  cardId,
+}: CreateCard & { cardId: number }) => {
+  const putCard = useCallback(
+    () =>
+      axiosAuthInstance.put<CreateCard>(`cards/${cardId}`, {
+        assigneeUserId,
+        title,
+        description,
+        dueDate,
+        tags,
+        imageUrl,
+      }),
+    [title, description, dueDate, tags, imageUrl, cardId]
+  );
+
+  const { execute, loading, error, data } = useAsync(putCard, true);
+
+  return {
+    execute,
+    loading,
+    error,
+    data,
+  };
+};
+
+export default usePutCard;

--- a/types/cards.ts
+++ b/types/cards.ts
@@ -1,18 +1,19 @@
 export interface CreateCard {
-  assigneeUserId: number;
-  dashboardId: number;
-  columnId: number;
+  assigneeUserId?: number | null;
+  dashboardId?: number;
+  columnId?: number;
   title: string;
   description: string;
-  dueDate: string | undefined;
-  tags: string[];
-  imageUrl: string | null;
+  dueDate?: string;
+  tags?: string[];
+  imageUrl?: string | null;
 }
 
 export interface Card {
   id: number;
   title: string;
   description: string;
+  dashboardId: number;
   tags: string[];
   dueDate: string;
   assignee: {


### PR DESCRIPTION
## 🛠️주요 변경 사항
- 할일수정 모달 구현
- 제목/설명 필드만 입력값있으면 수정버튼 활성화됩니다.
- 현재는 수정 후 새로고침하면 반영됩니다.

## 📣리뷰어에게 하고싶은 말
- 기존 카드에 이미지와 태그리스트가 반영되지 않아서 수정 예정입니다
- 모바일 상태 레이아웃이 병맛이에요.. 추천좀
- 저만 그런지 모르겠는데.. 자꾸 팡이는귀여워<< 계정이 대시보드멤버에 유령처럼 따라옵니다..

## 🖼️스크린샷(선택)
- 기본 레이아웃
<img width="255" alt="스크린샷 2024-01-04 오전 4 16 06" src="https://github.com/codeit-sprint-team1/Taskify/assets/120437902/a65abd93-ba68-48b6-a3b9-b7e55adc89e9">
<br>
<br>
<br>

- 드롭다운메뉴 보일때 너무 구려요.....
<img width="256" alt="스크린샷 2024-01-04 오전 4 16 57" src="https://github.com/codeit-sprint-team1/Taskify/assets/120437902/9d1e5b97-0f44-4180-b54e-baea1d8ae678">
<br>
<br>
<br>

- 입력값을 모두 지우면 팡이가 튀어나옴
<img width="256" alt="스크린샷 2024-01-04 오전 4 18 20" src="https://github.com/codeit-sprint-team1/Taskify/assets/120437902/208f7823-28c1-4ce1-951f-a4294dc7e6c6">



## ❗관련이슈
- close #21 
