### PR TITLE
refactor: 드롭다운 수정

### DIFF
--- a/components/modal/DropdownManager.tsx
+++ b/components/modal/DropdownManager.tsx
@@ -142,27 +142,33 @@ const DropdownManager = forwardRef<HTMLInputElement, DropdownManagerProps>(
             존재하지 않는 멤버입니다
           </p>
         )}
-        <ul ref={dropdownRef} className="max-h-180pxr overflow-y-auto">
-          {isOpen &&
-            filteredMembers.map((member) => (
-              <li key={member.id}>
-                <button
-                  className="block w-full hover:border hover:border-gray40 hover:rounded-md tablet:text-16pxr mobile:text-14pxr text-gray70 placeholder:text-gray40  "
-                  onClick={() => handleMemberClick(member)}
-                  tabIndex={0}
-                >
-                  <div className="flex items-center gap-6pxr pl-10pxr p-5pxr ">
-                    <ProfileImage
-                      src={member.profileImageUrl}
-                      name={member.nickname}
-                      size="sm"
-                    />
-                    {member.nickname}
-                  </div>
-                </button>
-              </li>
-            ))}
-        </ul>
+        <div className="relative">
+          {isOpen && (
+            <ul
+              ref={dropdownRef}
+              className="absolute right-0pxr mt-10pxr w-217pxr border border-2pxr border-gray30 rounded-lg p-8pxr bg-white tablet:text-16pxr mobile:text-14pxr"
+            >
+              {filteredMembers.map((member) => (
+                <li key={member.id}>
+                  <button
+                    className="w-full text-left px-10pxr py-5pxr rounded-md hover:bg-violet8 tablet:text-16pxr mobile:text-14pxr"
+                    onClick={() => handleMemberClick(member)}
+                    tabIndex={0}
+                  >
+                    <div className="flex items-center gap-6pxr pl-10pxr p-5pxr ">
+                      <ProfileImage
+                        src={member.profileImageUrl}
+                        name={member.nickname}
+                        size="sm"
+                      />
+                      {member.nickname}
+                    </div>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
       </div>
     );
   }

--- a/components/modal/DropdownManager.tsx
+++ b/components/modal/DropdownManager.tsx
@@ -14,7 +14,7 @@ import { Members } from '@/types/members';
 
 interface DropdownManagerProps {
   value?: string;
-  onChange?: (value: number) => void;
+  onChange?: (value: number | null) => void;
   dashboardId: number;
 }
 
@@ -42,6 +42,17 @@ const DropdownManager = forwardRef<HTMLInputElement, DropdownManagerProps>(
     const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
       const newValue = e.target.value;
       setInternalValue(newValue);
+
+      if (newValue === '') {
+        if (externalOnChange) externalOnChange(null);
+      } else {
+        const selectedMember = members.find(
+          (member) => member.nickname === newValue
+        );
+        if (selectedMember && externalOnChange) {
+          externalOnChange(selectedMember.userId);
+        }
+      }
     };
 
     const handleBlur = () => {

--- a/components/modal/DropdownManager.tsx
+++ b/components/modal/DropdownManager.tsx
@@ -42,7 +42,6 @@ const DropdownManager = forwardRef<HTMLInputElement, DropdownManagerProps>(
     const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
       const newValue = e.target.value;
       setInternalValue(newValue);
-      if (selectedMember || e.target.value) setIsMemberNotFound(false);
     };
 
     const handleBlur = () => {
@@ -60,7 +59,9 @@ const DropdownManager = forwardRef<HTMLInputElement, DropdownManagerProps>(
       const memberExists = members.some(
         (member) => member.nickname === internalValue
       );
-      setIsMemberNotFound(!memberExists && internalValue !== '');
+      setIsMemberNotFound(
+        !memberExists && internalValue !== '' && filteredMembers.length === 0
+      );
     };
 
     const handleOpenClick = () => {
@@ -143,7 +144,7 @@ const DropdownManager = forwardRef<HTMLInputElement, DropdownManagerProps>(
           </p>
         )}
         <div className="relative">
-          {isOpen && (
+          {isOpen && filteredMembers.length !== 0 && (
             <ul
               ref={dropdownRef}
               className="absolute right-0pxr mt-10pxr w-217pxr border border-2pxr border-gray30 rounded-lg p-8pxr bg-white tablet:text-16pxr mobile:text-14pxr"

--- a/components/modal/DropdownState.tsx
+++ b/components/modal/DropdownState.tsx
@@ -1,4 +1,4 @@
-import { MouseEvent, forwardRef, useEffect, useRef, useState } from 'react';
+import { forwardRef, useState } from 'react';
 import dropdownImage from '@/public/icons/dropdown-icon.svg';
 import Image from 'next/image';
 import { Label } from '..';
@@ -56,11 +56,11 @@ const DropdownState = forwardRef<HTMLInputElement, DropdownStateProps>(
             </button>
           </div>
           {isOpen && (
-            <ul className="overflow-y-auto max-h-160pxr">
+            <ul className="absolute right-0pxr mt-10pxr w-217pxr border border-2pxr border-gray30 rounded-lg p-8pxr bg-white tablet:text-16pxr mobile:text-14pxr">
               {states?.map((state) => (
                 <li key={state.id}>
                   <button
-                    className="block w-full hover:border hover:border-gray40 hover:rounded-md tablet:text-16pxr mobile:text-14pxr text-gray70 placeholder:text-gray40 "
+                    className="w-full text-left px-10pxr py-5pxr rounded-md hover:bg-violet8 tablet:text-16pxr mobile:text-14pxr"
                     onClick={() => handleStateClick(state)}
                   >
                     <div className="flex items-center gap-6pxr pl-10pxr p-5pxr ">

--- a/components/modal/SelectDate.tsx
+++ b/components/modal/SelectDate.tsx
@@ -20,12 +20,9 @@ export default function SelectDate({
   onChange,
 }: SelectDateProps) {
   const isPossibleDay = (date: Date) => {
-    const currentDate = new Date();
-    const selectedDate = new Date(date);
-
-    return currentDate.getDate() <= selectedDate.getDate();
+    const currentDate = DateTime.local();
+    return DateTime.fromJSDate(date) >= currentDate.startOf('day');
   };
-
   const handleDateChange = (
     date: Date | null,
     event: SyntheticEvent<any, Event> | undefined

--- a/components/modal/create-card/CreateCardModal.tsx
+++ b/components/modal/create-card/CreateCardModal.tsx
@@ -185,7 +185,6 @@ export default function CreateCardModal({
         >
           생성
         </ModalButton>
-        <DevTool control={control} />
       </div>
     </Modal>
   );

--- a/components/modal/edit-card/EditCardModal.tsx
+++ b/components/modal/edit-card/EditCardModal.tsx
@@ -192,7 +192,6 @@ export default function EditCardModal({
         <ModalButton disabled={!isValid || loading} onCancel={handleCancel}>
           수정
         </ModalButton>
-        <DevTool control={control} />
       </div>
     </Modal>
   );

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -32,7 +32,7 @@ body {
     @apply flex flex-col justify-between rounded-lg bg-violet8 pt-60pxr desktop:pt-100pxr w-1200pxr h-600pxr tablet:w-664pxr tablet:h-972pxr mobile:w-343pxr mobile:h-686pxr;
   }
   .react-datepicker {
-    @apply flex justify-center items-center;
+    @apply flex;
   }
 }
 


### PR DESCRIPTION
## 🛠️주요 변경 사항
- 드롭다운 디자인 변경(서영님 코드 참조)
- 드롭다운 멤버 선택 후 지워도 선택했던 멤버의 id값이 value에 남아있던 것 수정
- 드롭다운 담당자 클릭시 오류메시지 출력되던 현상 수정

[추가 변경 사항]
- datePicker 이전날짜 선택이 이번달만 안되어서 이전날짜 전체를 선택 못하도록 수정
- datePicker css(globalcss) 수정. (flex만 적용으로 변경) flex-center 적용하면 일수가 많아질때 빈틈이 생겨요 ㅠㅠ수정하지말아주세용


## 📣리뷰어에게 하고싶은 말
- 상태드롭다운은 할일수정 모달이 붙여진 후에 다시 살펴봐야 할것 같습니다. 현재는 담당자 드롭다운만 확인했어요!

## 🖼️스크린샷(선택)
- 기본디자인
<img width="270" alt="스크린샷 2024-01-04 오후 3 14 45" src="https://github.com/codeit-sprint-team1/Taskify/assets/120437902/aa0160ae-f7bd-4fc8-a541-fd83b0ca27ad">
<br>
<br>
<br>

- 담당자 삭제 시 입력값 null로 변경
<br>
<img width="193" alt="스크린샷 2024-01-04 오후 3 19 11" src="https://github.com/codeit-sprint-team1/Taskify/assets/120437902/f1be9a16-9c31-4191-86cc-006dfc97a259">


## ❗관련이슈
- close #136 
