### PR TITLE
fix: axios 헤더 accessToken 추가하여 해결

### DIFF
--- a/components/sign/form/LoginForm.tsx
+++ b/components/sign/form/LoginForm.tsx
@@ -10,6 +10,7 @@ import { useEffect } from 'react';
 import { Button, PasswordInput, Input } from '@/components';
 import { useLogin, useTokenRedirect } from '../data';
 import { useUserInfo } from '@/store/memos';
+import { axiosAuthInstance } from '@/utils';
 
 export default function LoginForm() {
   const { setUserInfo } = useUserInfo();
@@ -39,6 +40,12 @@ export default function LoginForm() {
       setUserInfo(data?.user);
     }
   }, [data?.user, setUserInfo]);
+
+  useEffect(() => {
+    if (data?.accessToken) {
+      axiosAuthInstance.defaults.headers.Authorization = `Bearer ${data.accessToken}`;
+    }
+  }, [data?.accessToken]);
 
   useEffect(() => {
     if (error) {

--- a/utils/axiosInstance.ts
+++ b/utils/axiosInstance.ts
@@ -1,11 +1,5 @@
 import axios from 'axios';
 
-function getLocalItem() {
-  if (typeof window !== 'undefined') return localStorage.getItem('accessToken');
-}
-
-const token = getLocalItem();
-
 export const axiosInstance = axios.create({
   baseURL: 'https://sp-taskify-api.vercel.app/1-1/',
 });
@@ -14,6 +8,5 @@ export const axiosAuthInstance = axios.create({
   baseURL: 'https://sp-taskify-api.vercel.app/1-1/',
   headers: {
     'Content-Type': 'application/json',
-    Authorization: `Bearer ${token}`,
   },
 });


### PR DESCRIPTION
## 🛠️주요 변경 사항
- axiosAuthInstance 헤더에 accessToken 넣는 방법 변경
    - ~~localStorage.getItem~~👉 로그인 할 때 `axiosAuthInstance.defaults.headers.Authorization = `Bearer ${data.accessToken}`

## 📣리뷰어에게 하고싶은 말
- 뻘짓 24시간째만에...!! 시간 낭비한 것 같아 죄송하네요ㅠㅠ (5줄 넣고 해결🥲)
- 로그인부터 다시하셔야 정상 작동 됩니다!
- 깨달은점: 그냥 막 수정해보지말고 공부를 하는게 빠를 수 있다. (axios에 대해서만 잘 알았어도...!!!)

## 🖼️스크린샷(선택)
찾아보다가 3가지 방법을 찾았는데, 우선 1️⃣번 방법이 확실히 되는 걸 확인해서 이걸로 적용했어요.
<br>
1️⃣ (현재적용⭐️)특정 axiosInstance 헤더에 넣을 값 지정하는 메소드(?). 한 번 넣어주면 해당 인스턴스 사용시 헤더에 자동으로 담긴다.
<br>
<img width="603" alt="Screen Shot 2024-01-04 at 22 43 07" src="https://github.com/codeit-sprint-team1/Taskify/assets/144652458/6c0c9d4d-5a16-4829-9e29-26a3ff928442">
<br>
2️⃣ axiosInstance를 만들때 인터셉트를 지정한다. 리퀘스트 중간에 특정 동작을 실행해 주는 역할
<img width="603" alt="Screen Shot 2024-01-04 at 22 42 51" src="https://github.com/codeit-sprint-team1/Taskify/assets/144652458/0cd0e845-38df-471d-9aac-b61fcb571d43">
<br>
3️⃣ token을 변수로 넣지 않고 함수를 넣어서 axiosAuthInstance 실행시마다 함수가 실행되어 가져오도록 한다.
<img width="603" alt="Screen Shot 2024-01-04 at 22 42 45" src="https://github.com/codeit-sprint-team1/Taskify/assets/144652458/94335572-0d73-4dc4-aafc-b788c249aba8">


## ❗관련이슈
- close #103 
